### PR TITLE
add extra mpi includes for systems that can't find mpi in input decks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,13 @@ if(MPI_CPPFLAGS)
   set(VPIC_CPPFLAGS "${string_cppflags}")
 endif(MPI_CPPFLAGS)
 
+# Append extra implicit includes
+string(REPLACE ";" " -I" string_cppflags "${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES}")
+set(VPIC_CPPFLAGS "${VPIC_CPPFLAGS} -I${string_cppflags}")
+message(${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+message(${VPIC_CPPFLAGS})
+
+
 string(REPLACE ";" " -I" string_includes "${MPI_C_INCLUDE_PATH}")
 if(NOT ${string_includes} STREQUAL "")
   set(VPIC_CXX_FLAGS "-I${string_includes} ${MPI_C_LINK_FLAGS}")


### PR DESCRIPTION
This aims to address #13, @SVLuedtke-LANL can you see if this addresses your issue? 