### PR TITLE
Improved Dump Semantics

### DIFF
--- a/sample/harris
+++ b/sample/harris
@@ -37,8 +37,6 @@ begin_globals {
 
 begin_initialization {
 
-  //particle_copy_interval = 2;
-
   // At this point, there is an empty grid and the random number generator is
   // seeded with the rank. The grid, materials, species need to be defined.
   // Then the initial non-zero fields need to be loaded at time level 0 and the

--- a/src/species_advance/species_advance.h
+++ b/src/species_advance/species_advance.h
@@ -130,6 +130,18 @@ class species_t {
         // And is basically the same as nm at certain times?
         int num_to_copy = 0;
 
+        // Step when the species was last copied to to the host.  The copy can
+        // take place at any time during the step, so checking
+        // species_copy_last==step() does not mean that the host and device
+        // data are the same.  Typically, copy is called immediately after the
+        // step is incremented and before or during user_diagnostics.  Checking
+        // species_copy_last==step() in these circumstances does mean the host
+        // is up to date, unless you do unusual stuff in user_diagnostics.
+        //
+        // This number is tracked on the host only, and may be inaccurate on
+        // the device.
+        int64_t species_copy_last = -1;
+
         // Init Kokkos Particle Arrays
         species_t(int n_particles, int n_pmovers) :
             k_p_d("k_particles", n_particles),

--- a/src/vpic/advance.cc
+++ b/src/vpic/advance.cc
@@ -646,22 +646,6 @@ int vpic_simulation::advance(void)
       update_profile( rank()==0 );
   }
 
-  // Optionally move data back from the device, at user request
-  if ( (particle_copy_interval > 0) && ((step() % particle_copy_interval) == 0))
-  {
-      // Copy particles back
-      KOKKOS_TIC(); // Time this data movement
-      KOKKOS_COPY_PARTICLE_MEM_TO_HOST(species_list);
-      KOKKOS_TOC( user_data_movement, 1);
-  }
-  if ( (field_copy_interval > 0) && ((step() % field_copy_interval) == 0))
-  {
-      // Copy fields back
-      KOKKOS_TIC(); // Time this data movement
-      KOKKOS_COPY_FIELD_MEM_TO_HOST(field_array);
-      KOKKOS_TOC( user_data_movement, 1);
-  }
-
   // Let the user compute diagnostics
   TIC user_diagnostics(); TOC( user_diagnostics, 1 );
 

--- a/src/vpic/vpic.h
+++ b/src/vpic/vpic.h
@@ -146,12 +146,9 @@ public:
   bool kokkos_field_injection = false;
   bool kokkos_current_injection = false;
   bool kokkos_particle_injection = false;
-  // Track how often the user wants us to copy data back from device
-  int field_copy_interval = -1;
-  int particle_copy_interval = -1;
   // Copy the last time-step on which we knowingly copied data back
-  int field_copy_last;
-  int particle_copy_last;
+  int64_t field_copy_last = -1;
+  int64_t particle_copy_last = -1;
 
   // FIXME: THESE INTERVALS SHOULDN'T BE PART OF vpic_simulation
   // THE BIG LIST FOLLOWING IT SHOULD BE CLEANED UP TOO
@@ -783,6 +780,22 @@ public:
   }
 
   /**
+   * @brief Copy all field data to the host, if it has not already been copied
+   * this step
+   *
+   * This does not guarantee that the particles are truly up to date, since it
+   * checks only if a copy has already been done at some point during the
+   * current step, but it will always work in user_diagnostics unless the loop
+   * is modified or a user modifies particles during user_diagnostics.  
+   *
+   */
+  void user_diagnostics_copy_field_mem_to_host()
+  {
+      if (step() > field_copy_last)
+          KOKKOS_COPY_FIELD_MEM_TO_HOST(field_array);
+  }
+
+  /**
    * @brief Copy all available particle memory from host to device, for a given
    * species list
    *
@@ -882,6 +895,8 @@ public:
               sp->pm[i].dispz = k_particle_movers_h(i, particle_mover_var::dispz);
               sp->pm[i].i     = k_particle_movers_i_h(i);
               });
+
+      sp->species_copy_last = step();
   }
 
   /**
@@ -895,6 +910,46 @@ public:
       auto* sp = species_list;
       LIST_FOR_EACH( sp, species_list ) {
           KOKKOS_COPY_PARTICLE_MEM_TO_HOST_SP(sp);
+      }
+  }
+
+  /**
+   * @brief Copy all available particle memory from device to host, for a given
+   * species, if it has not been copied this step
+   *
+   * This does not guarantee that the particles are truly up to date, since it
+   * checks only if a copy has already been done at some point during the
+   * current step, but it will always work in user_diagnostics unless the loop
+   * is modified or a user modifies particles during user_diagnostics.  
+   *
+   * @param speciesname the name of the species to copy
+   */
+  void user_diagnostics_copy_particles_mem_to_host(const char * speciesname)
+  {
+      species_t * sp = find_species_name(speciesname, species_list);
+      if(!sp) ERROR(( "Invalid Species name: %s", speciesname ));
+
+      if(step() > sp->species_copy_last)
+          KOKKOS_COPY_PARTICLE_MEM_TO_HOST_SP(sp);
+  }
+
+  /**
+   * @brief Copy all available particle memory from host to device, for a given
+   * list of species, if it has not been copied this step
+   *
+   * This does not guarantee that the particles are truly up to date, since it
+   * checks only if a copy has already been done at some point during the
+   * current step, but it will always work in user_diagnostics unless the loop
+   * is modified or a user modifies particles during user_diagnostics.  
+   *
+   * @param sp the species list to copy
+   */
+  void user_diagnostics_copy_all_particles_mem_to_host(species_t* species_list)
+  {
+      auto* sp = species_list;
+      LIST_FOR_EACH( sp, species_list ) {
+          if(step() > sp->species_copy_last)
+          KOKKOS_COPY_PARTICLE_MEM_TO_DEVICE_SP(sp);
       }
   }
 


### PR DESCRIPTION
Semantics for the built-in dumps are now the same as in the non-Kokkos version.  The dump functions themselves handle the device to host copy, and will check if the data are already current.

Also provided are user_diagnostics_copy_*_mem_to_host functions for users to easily copy data to the host for their diagnostics.  These will also check if the data are already current.