### PR TITLE
Field buffers for MPI communication are allocated once only

### DIFF
--- a/src/field_advance/field_advance.h
+++ b/src/field_advance/field_advance.h
@@ -306,17 +306,19 @@ typedef struct field_array {
   k_field_accum_t k_f_rhob_accum_d;//TODO: Remove when absorbing pbc on device
   k_field_accum_t::HostMirror k_f_rhob_accum_h;
 
-  field_buffers_t* fb;
+  field_buffers_t fb;
 
   // Initialize Kokkos Field Array
-  field_array(int n_fields) :
+  field_array(int n_fields, int xyz_sz, int yzx_sz, int zxy_sz) :
     k_f_d("k_fields", n_fields),
     k_fe_d("k_field_edges", n_fields),
-    k_f_rhob_accum_d("k_rhob_accum", n_fields)//TODO: does this zero the array?
+    k_f_rhob_accum_d("k_rhob_accum", n_fields),//TODO: does this zero the array?
+    fb(xyz_sz, yzx_sz, zxy_sz)
   {
     k_f_h = Kokkos::create_mirror_view(k_f_d);
     k_fe_h = Kokkos::create_mirror_view(k_fe_d);
     k_f_rhob_accum_h = Kokkos::create_mirror_view(k_f_rhob_accum_d);
+
   }
 
 } field_array_t;

--- a/src/field_advance/standard/advance_e.cc
+++ b/src/field_advance/standard/advance_e.cc
@@ -665,7 +665,7 @@ void advance_e_kokkos(field_array_t* RESTRICT fa, float frac) {
     * Begin tangential B ghost setup
     ***************************************************************************/
 
-    kokkos_begin_remote_ghost_tang_b( fa, fa->g, *fa->fb );
+    kokkos_begin_remote_ghost_tang_b( fa, fa->g, fa->fb );
 
     k_local_ghost_tang_b( fa, fa->g );
 
@@ -675,7 +675,7 @@ void advance_e_kokkos(field_array_t* RESTRICT fa, float frac) {
     * Finish tangential B ghost setup
     ***************************************************************************/
 
-    kokkos_end_remote_ghost_tang_b( fa, fa->g, *fa->fb );
+    kokkos_end_remote_ghost_tang_b( fa, fa->g, fa->fb );
 
     /***************************************************************************
     * Update exterior fields

--- a/src/field_advance/standard/clean_div_b.cc
+++ b/src/field_advance/standard/clean_div_b.cc
@@ -391,7 +391,7 @@ clean_div_b_kokkos( field_array_t * fa ) {
 # endif
 
     // Begin setting derr ghosts
-    k_begin_remote_ghost_div_b( fa, g, *fa->fb);
+    k_begin_remote_ghost_div_b( fa, g, fa->fb);
     k_local_ghost_div_b( fa, g);
 
   // Have pipelines do interior of the local domain
@@ -504,7 +504,7 @@ clean_div_b_kokkos( field_array_t * fa ) {
 */
   // Finish setting derr ghosts
 
-  k_end_remote_ghost_div_b( fa, g, *fa->fb );
+  k_end_remote_ghost_div_b( fa, g, fa->fb );
 
   // Do Marder pass in exterior
 

--- a/src/field_advance/standard/remote.cc
+++ b/src/field_advance/standard/remote.cc
@@ -1800,32 +1800,32 @@ synchronize_tang_e_norm_b_kokkos( field_array_t * RESTRICT fa ) {
     k_local_adjust_norm_b( fa, g );
 
     // Exchange x-faces
-    begin_recv_tang_e_norm_b<XYZ>(fa, -1,  0,  0, fa->fb->xyz_rbuf_neg, fa->fb->xyz_rbuf_neg_h);
-    begin_recv_tang_e_norm_b<XYZ>(fa,  1,  0,  0, fa->fb->xyz_rbuf_pos, fa->fb->xyz_rbuf_pos_h);
-    begin_send_tang_e_norm_b<XYZ>(fa, -1,  0,  0, fa->fb->xyz_sbuf_neg, fa->fb->xyz_sbuf_neg_h);
-    begin_send_tang_e_norm_b<XYZ>(fa,  1,  0,  0, fa->fb->xyz_sbuf_pos, fa->fb->xyz_sbuf_pos_h);
-    err += end_recv_tang_e_norm_b<XYZ>(fa,  -1,  0,  0, fa->fb->xyz_rbuf_neg, fa->fb->xyz_rbuf_neg_h);
-    err += end_recv_tang_e_norm_b<XYZ>(fa,   1,  0,  0, fa->fb->xyz_rbuf_pos, fa->fb->xyz_rbuf_pos_h);
+    begin_recv_tang_e_norm_b<XYZ>(fa, -1,  0,  0, fa->fb.xyz_rbuf_neg, fa->fb.xyz_rbuf_neg_h);
+    begin_recv_tang_e_norm_b<XYZ>(fa,  1,  0,  0, fa->fb.xyz_rbuf_pos, fa->fb.xyz_rbuf_pos_h);
+    begin_send_tang_e_norm_b<XYZ>(fa, -1,  0,  0, fa->fb.xyz_sbuf_neg, fa->fb.xyz_sbuf_neg_h);
+    begin_send_tang_e_norm_b<XYZ>(fa,  1,  0,  0, fa->fb.xyz_sbuf_pos, fa->fb.xyz_sbuf_pos_h);
+    err += end_recv_tang_e_norm_b<XYZ>(fa,  -1,  0,  0, fa->fb.xyz_rbuf_neg, fa->fb.xyz_rbuf_neg_h);
+    err += end_recv_tang_e_norm_b<XYZ>(fa,   1,  0,  0, fa->fb.xyz_rbuf_pos, fa->fb.xyz_rbuf_pos_h);
     end_send_tang_e_norm_b<XYZ>(fa,  -1,  0,  0);
     end_send_tang_e_norm_b<XYZ>(fa,   1,  0,  0);
 
     // Exchange y-faces
-    begin_recv_tang_e_norm_b<YZX>(fa,  0, -1,  0, fa->fb->yzx_rbuf_neg, fa->fb->yzx_rbuf_neg_h);
-    begin_recv_tang_e_norm_b<YZX>(fa,  0,  1,  0, fa->fb->yzx_rbuf_pos, fa->fb->yzx_rbuf_pos_h);
-    begin_send_tang_e_norm_b<YZX>(fa,  0, -1,  0, fa->fb->yzx_sbuf_neg, fa->fb->yzx_sbuf_neg_h);
-    begin_send_tang_e_norm_b<YZX>(fa,  0,  1,  0, fa->fb->yzx_sbuf_pos, fa->fb->yzx_sbuf_pos_h);
-    err += end_recv_tang_e_norm_b<YZX>(fa,   0, -1,  0, fa->fb->yzx_rbuf_neg, fa->fb->yzx_rbuf_neg_h);
-    err += end_recv_tang_e_norm_b<YZX>(fa,   0,  1,  0, fa->fb->yzx_rbuf_pos, fa->fb->yzx_rbuf_pos_h);
+    begin_recv_tang_e_norm_b<YZX>(fa,  0, -1,  0, fa->fb.yzx_rbuf_neg, fa->fb.yzx_rbuf_neg_h);
+    begin_recv_tang_e_norm_b<YZX>(fa,  0,  1,  0, fa->fb.yzx_rbuf_pos, fa->fb.yzx_rbuf_pos_h);
+    begin_send_tang_e_norm_b<YZX>(fa,  0, -1,  0, fa->fb.yzx_sbuf_neg, fa->fb.yzx_sbuf_neg_h);
+    begin_send_tang_e_norm_b<YZX>(fa,  0,  1,  0, fa->fb.yzx_sbuf_pos, fa->fb.yzx_sbuf_pos_h);
+    err += end_recv_tang_e_norm_b<YZX>(fa,   0, -1,  0, fa->fb.yzx_rbuf_neg, fa->fb.yzx_rbuf_neg_h);
+    err += end_recv_tang_e_norm_b<YZX>(fa,   0,  1,  0, fa->fb.yzx_rbuf_pos, fa->fb.yzx_rbuf_pos_h);
     end_send_tang_e_norm_b<YZX>(fa,   0, -1,  0);
     end_send_tang_e_norm_b<YZX>(fa,   0,  1,  0);
 
     // Exchange z-faces
-    begin_recv_tang_e_norm_b<ZXY>(fa,  0,  0, -1, fa->fb->zxy_rbuf_neg, fa->fb->zxy_rbuf_neg_h);
-    begin_recv_tang_e_norm_b<ZXY>(fa,  0,  0,  1, fa->fb->zxy_rbuf_pos, fa->fb->zxy_rbuf_pos_h);
-    begin_send_tang_e_norm_b<ZXY>(fa,  0,  0, -1, fa->fb->zxy_sbuf_neg, fa->fb->zxy_sbuf_neg_h);
-    begin_send_tang_e_norm_b<ZXY>(fa,  0,  0,  1, fa->fb->zxy_sbuf_pos, fa->fb->zxy_sbuf_pos_h);
-    err += end_recv_tang_e_norm_b<ZXY>(fa,   0,  0, -1, fa->fb->zxy_rbuf_neg, fa->fb->zxy_rbuf_neg_h);
-    err += end_recv_tang_e_norm_b<ZXY>(fa,   0,  0,  1, fa->fb->zxy_rbuf_pos, fa->fb->zxy_rbuf_pos_h);
+    begin_recv_tang_e_norm_b<ZXY>(fa,  0,  0, -1, fa->fb.zxy_rbuf_neg, fa->fb.zxy_rbuf_neg_h);
+    begin_recv_tang_e_norm_b<ZXY>(fa,  0,  0,  1, fa->fb.zxy_rbuf_pos, fa->fb.zxy_rbuf_pos_h);
+    begin_send_tang_e_norm_b<ZXY>(fa,  0,  0, -1, fa->fb.zxy_sbuf_neg, fa->fb.zxy_sbuf_neg_h);
+    begin_send_tang_e_norm_b<ZXY>(fa,  0,  0,  1, fa->fb.zxy_sbuf_pos, fa->fb.zxy_sbuf_pos_h);
+    err += end_recv_tang_e_norm_b<ZXY>(fa,   0,  0, -1, fa->fb.zxy_rbuf_neg, fa->fb.zxy_rbuf_neg_h);
+    err += end_recv_tang_e_norm_b<ZXY>(fa,   0,  0,  1, fa->fb.zxy_rbuf_pos, fa->fb.zxy_rbuf_pos_h);
     end_send_tang_e_norm_b<ZXY>(fa,   0,  0, -1);
     end_send_tang_e_norm_b<ZXY>(fa,   0,  0,  1);
 
@@ -2107,32 +2107,32 @@ void k_synchronize_jf(field_array_t* RESTRICT fa) {
     k_local_adjust_jf(fa, g);
 
     // Exchange x-faces
-    begin_recv_jf<XYZ>(g, -1, 0, 0, nx, ny, nz, fa->fb->xyz_rbuf_neg, fa->fb->xyz_rbuf_neg_h);
-    begin_recv_jf<XYZ>(g,  1, 0, 0, nx, ny, nz, fa->fb->xyz_rbuf_pos, fa->fb->xyz_rbuf_pos_h);
-    begin_send_jf<XYZ>(g, fa, -1, 0, 0, nx, ny, nz, fa->fb->xyz_sbuf_neg, fa->fb->xyz_sbuf_neg_h);
-    begin_send_jf<XYZ>(g, fa,  1, 0, 0, nx, ny, nz, fa->fb->xyz_sbuf_pos, fa->fb->xyz_sbuf_pos_h);
-    end_recv_jf<XYZ>(g, fa, -1, 0, 0, nx, ny, nz, fa->fb->xyz_rbuf_neg, fa->fb->xyz_rbuf_neg_h);
-    end_recv_jf<XYZ>(g, fa,  1, 0, 0, nx, ny, nz, fa->fb->xyz_rbuf_pos, fa->fb->xyz_rbuf_pos_h);
+    begin_recv_jf<XYZ>(g, -1, 0, 0, nx, ny, nz, fa->fb.xyz_rbuf_neg, fa->fb.xyz_rbuf_neg_h);
+    begin_recv_jf<XYZ>(g,  1, 0, 0, nx, ny, nz, fa->fb.xyz_rbuf_pos, fa->fb.xyz_rbuf_pos_h);
+    begin_send_jf<XYZ>(g, fa, -1, 0, 0, nx, ny, nz, fa->fb.xyz_sbuf_neg, fa->fb.xyz_sbuf_neg_h);
+    begin_send_jf<XYZ>(g, fa,  1, 0, 0, nx, ny, nz, fa->fb.xyz_sbuf_pos, fa->fb.xyz_sbuf_pos_h);
+    end_recv_jf<XYZ>(g, fa, -1, 0, 0, nx, ny, nz, fa->fb.xyz_rbuf_neg, fa->fb.xyz_rbuf_neg_h);
+    end_recv_jf<XYZ>(g, fa,  1, 0, 0, nx, ny, nz, fa->fb.xyz_rbuf_pos, fa->fb.xyz_rbuf_pos_h);
     end_send_jf<XYZ>(g, -1, 0, 0);
     end_send_jf<XYZ>(g,  1, 0, 0);
 
     // Exchange y-faces
-    begin_recv_jf<YZX>(g, 0, -1, 0, nx, ny, nz, fa->fb->yzx_rbuf_neg, fa->fb->yzx_rbuf_neg_h);
-    begin_recv_jf<YZX>(g, 0,  1, 0, nx, ny, nz, fa->fb->yzx_rbuf_pos, fa->fb->yzx_rbuf_pos_h);
-    begin_send_jf<YZX>(g, fa, 0, -1, 0, nx, ny, nz, fa->fb->yzx_sbuf_neg, fa->fb->yzx_sbuf_neg_h);
-    begin_send_jf<YZX>(g, fa, 0,  1, 0, nx, ny, nz, fa->fb->yzx_sbuf_pos, fa->fb->yzx_sbuf_pos_h);
-    end_recv_jf<YZX>(g, fa, 0, -1, 0, nx, ny, nz, fa->fb->yzx_rbuf_neg, fa->fb->yzx_rbuf_neg_h);
-    end_recv_jf<YZX>(g, fa, 0,  1, 0, nx, ny, nz, fa->fb->yzx_rbuf_pos, fa->fb->yzx_rbuf_pos_h);
+    begin_recv_jf<YZX>(g, 0, -1, 0, nx, ny, nz, fa->fb.yzx_rbuf_neg, fa->fb.yzx_rbuf_neg_h);
+    begin_recv_jf<YZX>(g, 0,  1, 0, nx, ny, nz, fa->fb.yzx_rbuf_pos, fa->fb.yzx_rbuf_pos_h);
+    begin_send_jf<YZX>(g, fa, 0, -1, 0, nx, ny, nz, fa->fb.yzx_sbuf_neg, fa->fb.yzx_sbuf_neg_h);
+    begin_send_jf<YZX>(g, fa, 0,  1, 0, nx, ny, nz, fa->fb.yzx_sbuf_pos, fa->fb.yzx_sbuf_pos_h);
+    end_recv_jf<YZX>(g, fa, 0, -1, 0, nx, ny, nz, fa->fb.yzx_rbuf_neg, fa->fb.yzx_rbuf_neg_h);
+    end_recv_jf<YZX>(g, fa, 0,  1, 0, nx, ny, nz, fa->fb.yzx_rbuf_pos, fa->fb.yzx_rbuf_pos_h);
     end_send_jf<YZX>(g, 0, -1, 0);
     end_send_jf<YZX>(g, 0,  1, 0);
 
     // Exchange z-faces
-    begin_recv_jf<ZXY>(g, 0, 0, -1, nx, ny, nz, fa->fb->zxy_rbuf_neg, fa->fb->zxy_rbuf_neg_h);
-    begin_recv_jf<ZXY>(g, 0, 0,  1, nx, ny, nz, fa->fb->zxy_rbuf_pos, fa->fb->zxy_rbuf_pos_h);
-    begin_send_jf<ZXY>(g, fa, 0, 0, -1, nx, ny, nz, fa->fb->zxy_sbuf_neg, fa->fb->zxy_sbuf_neg_h);
-    begin_send_jf<ZXY>(g, fa, 0, 0,  1, nx, ny, nz, fa->fb->zxy_sbuf_pos, fa->fb->zxy_sbuf_pos_h);
-    end_recv_jf<ZXY>(g, fa, 0, 0, -1, nx, ny, nz, fa->fb->zxy_rbuf_neg, fa->fb->zxy_rbuf_neg_h);
-    end_recv_jf<ZXY>(g, fa, 0, 0,  1, nx, ny, nz, fa->fb->zxy_rbuf_pos, fa->fb->zxy_rbuf_pos_h);
+    begin_recv_jf<ZXY>(g, 0, 0, -1, nx, ny, nz, fa->fb.zxy_rbuf_neg, fa->fb.zxy_rbuf_neg_h);
+    begin_recv_jf<ZXY>(g, 0, 0,  1, nx, ny, nz, fa->fb.zxy_rbuf_pos, fa->fb.zxy_rbuf_pos_h);
+    begin_send_jf<ZXY>(g, fa, 0, 0, -1, nx, ny, nz, fa->fb.zxy_sbuf_neg, fa->fb.zxy_sbuf_neg_h);
+    begin_send_jf<ZXY>(g, fa, 0, 0,  1, nx, ny, nz, fa->fb.zxy_sbuf_pos, fa->fb.zxy_sbuf_pos_h);
+    end_recv_jf<ZXY>(g, fa, 0, 0, -1, nx, ny, nz, fa->fb.zxy_rbuf_neg, fa->fb.zxy_rbuf_neg_h);
+    end_recv_jf<ZXY>(g, fa, 0, 0,  1, nx, ny, nz, fa->fb.zxy_rbuf_pos, fa->fb.zxy_rbuf_pos_h);
     end_send_jf<ZXY>(g, 0, 0, -1);
     end_send_jf<ZXY>(g, 0, 0,  1);
 
@@ -2410,32 +2410,32 @@ void k_synchronize_rho(field_array_t* RESTRICT fa) {
     k_local_adjust_rhob(fa, g);
 
     // Exchange x-faces
-    begin_recv_rho<XYZ>(fa, -1, 0, 0, nx, ny, nz, fa->fb->xyz_rbuf_neg, fa->fb->xyz_rbuf_neg_h);
-    begin_recv_rho<XYZ>(fa,  1, 0, 0, nx, ny, nz, fa->fb->xyz_rbuf_pos, fa->fb->xyz_rbuf_pos_h);
-    begin_send_rho<XYZ>(fa, -1, 0, 0, nx, ny, nz, fa->fb->xyz_sbuf_neg, fa->fb->xyz_sbuf_neg_h);
-    begin_send_rho<XYZ>(fa,  1, 0, 0, nx, ny, nz, fa->fb->xyz_sbuf_pos, fa->fb->xyz_sbuf_pos_h);
-    end_recv_rho<XYZ>(  fa, -1, 0, 0, nx, ny, nz, fa->fb->xyz_rbuf_neg, fa->fb->xyz_rbuf_neg_h);
-    end_recv_rho<XYZ>(  fa,  1, 0, 0, nx, ny, nz, fa->fb->xyz_rbuf_pos, fa->fb->xyz_rbuf_pos_h);
+    begin_recv_rho<XYZ>(fa, -1, 0, 0, nx, ny, nz, fa->fb.xyz_rbuf_neg, fa->fb.xyz_rbuf_neg_h);
+    begin_recv_rho<XYZ>(fa,  1, 0, 0, nx, ny, nz, fa->fb.xyz_rbuf_pos, fa->fb.xyz_rbuf_pos_h);
+    begin_send_rho<XYZ>(fa, -1, 0, 0, nx, ny, nz, fa->fb.xyz_sbuf_neg, fa->fb.xyz_sbuf_neg_h);
+    begin_send_rho<XYZ>(fa,  1, 0, 0, nx, ny, nz, fa->fb.xyz_sbuf_pos, fa->fb.xyz_sbuf_pos_h);
+    end_recv_rho<XYZ>(  fa, -1, 0, 0, nx, ny, nz, fa->fb.xyz_rbuf_neg, fa->fb.xyz_rbuf_neg_h);
+    end_recv_rho<XYZ>(  fa,  1, 0, 0, nx, ny, nz, fa->fb.xyz_rbuf_pos, fa->fb.xyz_rbuf_pos_h);
     end_send_rho<XYZ>(  fa, -1, 0, 0);
     end_send_rho<XYZ>(  fa,  1, 0, 0);
 
     // Exchange y-faces
-    begin_recv_rho<YZX>(fa, 0, -1, 0, nx, ny, nz, fa->fb->yzx_rbuf_neg, fa->fb->yzx_rbuf_neg_h);
-    begin_recv_rho<YZX>(fa, 0,  1, 0, nx, ny, nz, fa->fb->yzx_rbuf_pos, fa->fb->yzx_rbuf_pos_h);
-    begin_send_rho<YZX>(fa, 0, -1, 0, nx, ny, nz, fa->fb->yzx_sbuf_neg, fa->fb->yzx_sbuf_neg_h);
-    begin_send_rho<YZX>(fa, 0,  1, 0, nx, ny, nz, fa->fb->yzx_sbuf_pos, fa->fb->yzx_sbuf_pos_h);
-    end_recv_rho<YZX>(  fa, 0, -1, 0, nx, ny, nz, fa->fb->yzx_rbuf_neg, fa->fb->yzx_rbuf_neg_h);
-    end_recv_rho<YZX>(  fa, 0,  1, 0, nx, ny, nz, fa->fb->yzx_rbuf_pos, fa->fb->yzx_rbuf_pos_h);
+    begin_recv_rho<YZX>(fa, 0, -1, 0, nx, ny, nz, fa->fb.yzx_rbuf_neg, fa->fb.yzx_rbuf_neg_h);
+    begin_recv_rho<YZX>(fa, 0,  1, 0, nx, ny, nz, fa->fb.yzx_rbuf_pos, fa->fb.yzx_rbuf_pos_h);
+    begin_send_rho<YZX>(fa, 0, -1, 0, nx, ny, nz, fa->fb.yzx_sbuf_neg, fa->fb.yzx_sbuf_neg_h);
+    begin_send_rho<YZX>(fa, 0,  1, 0, nx, ny, nz, fa->fb.yzx_sbuf_pos, fa->fb.yzx_sbuf_pos_h);
+    end_recv_rho<YZX>(  fa, 0, -1, 0, nx, ny, nz, fa->fb.yzx_rbuf_neg, fa->fb.yzx_rbuf_neg_h);
+    end_recv_rho<YZX>(  fa, 0,  1, 0, nx, ny, nz, fa->fb.yzx_rbuf_pos, fa->fb.yzx_rbuf_pos_h);
     end_send_rho<YZX>(  fa, 0, -1, 0);
     end_send_rho<YZX>(  fa, 0,  1, 0);
 
     // Exchange z-faces
-    begin_recv_rho<ZXY>(fa, 0, 0, -1, nx, ny, nz, fa->fb->zxy_rbuf_neg, fa->fb->zxy_rbuf_neg_h);
-    begin_recv_rho<ZXY>(fa, 0, 0,  1, nx, ny, nz, fa->fb->zxy_rbuf_pos, fa->fb->zxy_rbuf_pos_h);
-    begin_send_rho<ZXY>(fa, 0, 0, -1, nx, ny, nz, fa->fb->zxy_sbuf_neg, fa->fb->zxy_sbuf_neg_h);
-    begin_send_rho<ZXY>(fa, 0, 0,  1, nx, ny, nz, fa->fb->zxy_sbuf_pos, fa->fb->zxy_sbuf_pos_h);
-    end_recv_rho<ZXY>(  fa, 0, 0, -1, nx, ny, nz, fa->fb->zxy_rbuf_neg, fa->fb->zxy_rbuf_neg_h);
-    end_recv_rho<ZXY>(  fa, 0, 0,  1, nx, ny, nz, fa->fb->zxy_rbuf_pos, fa->fb->zxy_rbuf_pos_h);
+    begin_recv_rho<ZXY>(fa, 0, 0, -1, nx, ny, nz, fa->fb.zxy_rbuf_neg, fa->fb.zxy_rbuf_neg_h);
+    begin_recv_rho<ZXY>(fa, 0, 0,  1, nx, ny, nz, fa->fb.zxy_rbuf_pos, fa->fb.zxy_rbuf_pos_h);
+    begin_send_rho<ZXY>(fa, 0, 0, -1, nx, ny, nz, fa->fb.zxy_sbuf_neg, fa->fb.zxy_sbuf_neg_h);
+    begin_send_rho<ZXY>(fa, 0, 0,  1, nx, ny, nz, fa->fb.zxy_sbuf_pos, fa->fb.zxy_sbuf_pos_h);
+    end_recv_rho<ZXY>(  fa, 0, 0, -1, nx, ny, nz, fa->fb.zxy_rbuf_neg, fa->fb.zxy_rbuf_neg_h);
+    end_recv_rho<ZXY>(  fa, 0, 0,  1, nx, ny, nz, fa->fb.zxy_rbuf_pos, fa->fb.zxy_rbuf_pos_h);
     end_send_rho<ZXY>(  fa, 0, 0, -1);
     end_send_rho<ZXY>(  fa, 0, 0,  1);
 

--- a/src/field_advance/standard/sfa.cc
+++ b/src/field_advance/standard/sfa.cc
@@ -217,7 +217,14 @@ new_standard_field_array( grid_t           * RESTRICT g,
                           float                       damp ) {
   field_array_t * fa;
   if( !g || !m_list || damp<0 ) ERROR(( "Bad args" ));
-  fa = new field_array_t(g->nv);
+
+  int nx = g->nx;
+  int ny = g->ny;
+  int nz = g->nz;
+  int xyz_sz = 2*ny*(nz+1) + 2*nz*(ny+1) + ny*nz;
+  int yzx_sz = 2*nz*(nx+1) + 2*nx*(nz+1) + nz*nx;
+  int zxy_sz = 2*nx*(ny+1) + 2*ny*(nx+1) + nx*ny;
+  fa = new field_array_t(g->nv, xyz_sz, yzx_sz, zxy_sz);
   // Zero host accum array
   Kokkos::parallel_for("Clear rhob accumulation array on host", host_execution_policy(0, g->nv), KOKKOS_LAMBDA (int i) {
           fa->k_f_rhob_accum_h(i) = 0;
@@ -242,15 +249,6 @@ new_standard_field_array( grid_t           * RESTRICT g,
     fa->kernel->clean_div_e_kokkos= vacuum_clean_div_e_kokkos;
     fa->kernel->energy_f_kokkos   = vacuum_energy_f_kokkos;
   }
-  int nx = g->nx;
-  int ny = g->ny;
-  int nz = g->nz;
-
-  int xyz_sz = 2*ny*(nz+1) + 2*nz*(ny+1) + ny*nz;
-  int yzx_sz = 2*nz*(nx+1) + 2*nx*(nz+1) + nz*nx;
-  int zxy_sz = 2*nx*(ny+1) + 2*ny*(nx+1) + nx*ny;
-  static field_buffers_t buffs = field_buffers(xyz_sz, yzx_sz, zxy_sz);
-  fa->fb = &buffs;
 
   REGISTER_OBJECT( fa, checkpt_standard_field_array,
                        restore_standard_field_array, NULL );

--- a/src/field_advance/standard/vacuum_advance_e.cc
+++ b/src/field_advance/standard/vacuum_advance_e.cc
@@ -592,7 +592,7 @@ vacuum_advance_e_kokkos( field_array_t * RESTRICT fa,
    ***************************************************************************/
   
 //    k_begin_remote_ghost_tang_b( fa, fa->g );
-    kokkos_begin_remote_ghost_tang_b(fa, fa->g, *fa->fb);
+    kokkos_begin_remote_ghost_tang_b(fa, fa->g, fa->fb);
 
     k_local_ghost_tang_b( fa, fa->g );
 
@@ -603,7 +603,7 @@ vacuum_advance_e_kokkos( field_array_t * RESTRICT fa,
    ***************************************************************************/
 
 //    k_end_remote_ghost_tang_b( fa, fa->g );
-    kokkos_end_remote_ghost_tang_b(fa, fa->g, *fa->fb);
+    kokkos_end_remote_ghost_tang_b(fa, fa->g, fa->fb);
 
   /***************************************************************************
    * Update exterior fields

--- a/src/field_advance/standard/vacuum_compute_div_e_err.cc
+++ b/src/field_advance/standard/vacuum_compute_div_e_err.cc
@@ -315,7 +315,7 @@ vacuum_compute_div_e_err_kokkos( field_array_t * RESTRICT fa ) {
   // Begin setting normal e ghosts
 
 //  k_begin_remote_ghost_norm_e( fa, fa->g );
-  kokkos_begin_remote_ghost_norm_e( fa, fa->g, *fa->fb );
+  kokkos_begin_remote_ghost_norm_e( fa, fa->g, fa->fb );
 
   k_local_ghost_norm_e( fa, fa->g );
 
@@ -328,7 +328,7 @@ vacuum_compute_div_e_err_kokkos( field_array_t * RESTRICT fa ) {
 
   // Finish setting normal e ghosts
 //  k_end_remote_ghost_norm_e( fa, fa->g );
-  kokkos_end_remote_ghost_norm_e( fa, fa->g, *fa->fb );
+  kokkos_end_remote_ghost_norm_e( fa, fa->g, fa->fb );
 
     vacuum_compute_div_e_err_exterior_kokkos(fa, fa->g);
 


### PR DESCRIPTION
Previously, field buffers were allocated and deallocated every timestep.  Now there is one allocation during initialization.