### PR TITLE
WIP: Reduce accum data copy by half

### DIFF
--- a/src/boundary/boundary_p.cc
+++ b/src/boundary/boundary_p.cc
@@ -65,18 +65,6 @@ boundary_p_kokkos(
       )
 {
 
-  // TODO: this doesn't need to be made every time
-  // Make scatter add ON HOST
-  // TODO: hard coding OpenMP here is not good
-  /*
-  Kokkos::Experimental::ScatterView<float
-      *[ACCUMULATOR_VAR_COUNT][ACCUMULATOR_ARRAY_LENGTH], Kokkos::LayoutLeft,
-      Kokkos::OpenMP, Kokkos::Experimental::ScatterSum,
-      Kokkos::Experimental::ScatterDuplicated ,
-      Kokkos::Experimental::ScatterNonAtomic > scatter_add =
-          Kokkos::Experimental::create_scatter_view(aa->k_a_h);
-          */
-
   // Temporary store for local particle injectors
   // FIXME: Ugly static usage
   static particle_injector_t * RESTRICT ALIGNED(16) ci = NULL;
@@ -450,6 +438,7 @@ boundary_p_kokkos(
 
       // TODO: the benefit of doing this backwards goes away
       pi += n-1;
+
       for( ; n; pi--, n-- ) {
         id = pi->sp_id;
 
@@ -501,7 +490,6 @@ boundary_p_kokkos(
 
         // Don't update np yet, we have not copied it back
         //sp_np[id] = np+1;
-
         pm[nm].dispx=pi->dispx; pm[nm].dispy=pi->dispy; pm[nm].dispz=pi->dispz;
 
         //pm[nm].i=np;
@@ -509,6 +497,7 @@ boundary_p_kokkos(
 
         // TODO: this relies on serial for now -- maybe bad?
         //sp_nm[id] = nm + move_p( p, pm+nm, a0, g, sp_q[id] );
+        std::cout << "Calling move_p" << std::endl;
         int ret_code = move_p_kokkos_host_serial(
                 particle_recv,
                 particle_recv_i,
@@ -573,9 +562,9 @@ boundary_p_kokkos(
       // Zero host accum array
       Kokkos::parallel_for("Clear rhob accumulation array on host", host_execution_policy(0, n_fields - 1), KOKKOS_LAMBDA (int i) {
               kfah(i) = 0;
-              });
-
+      });
   }
+
   // contribute SA back
   //Kokkos::Experimental::contribute(aa->k_a_h, scatter_add);
 }

--- a/src/sf_interface/accumulator_array.cc
+++ b/src/sf_interface/accumulator_array.cc
@@ -47,7 +47,8 @@ new_accumulator_array( grid_t * g ) {
   //printf("Making %d copies of accumulator \n",aa_n_pipeline()+1 );
   aa = new accumulator_array_t(
           //(size_t)(aa->n_pipeline+1)*(size_t)aa->stride,
-          (size_t)(aa_n_pipeline()+1)*(size_t)(POW2_CEIL(g->nv,2))
+          //(size_t)(aa_n_pipeline()+1)*(size_t)(POW2_CEIL(g->nv,2))
+          g->nv
   );
   aa->n_pipeline = aa_n_pipeline();
   aa->stride     = POW2_CEIL(g->nv,2);

--- a/src/sf_interface/unload_accumulator.cc
+++ b/src/sf_interface/unload_accumulator.cc
@@ -117,6 +117,41 @@ unload_accumulator_array( /**/  field_array_t       * RESTRICT fa,
 }
 
 void
+combine_accumulators(accumulator_array_t* RESTRICT aa)
+{
+    // TODO: this is likely faster with a 3d policy
+    //Kokkos::MDRangePolicy<Kokkos::Rank<3>> unload_policy({1, 1, 1}, {nz+2, ny+2, nx+2});
+    k_accumulators_t& k_accum_d = aa->k_a_d;
+    k_accumulators_t& k_accum_copy = aa->k_a_d_copy;
+
+    auto& k_accum_h = aa->k_a_h;
+    Kokkos::deep_copy(k_accum_copy, k_accum_h);
+
+    int nv = aa->g->nv;
+    //std::cout << " nv " << nv << " size " << k_accum_d.size() << " extent " << k_accum_d.extent(0) << std::endl;
+    // TODO: why is extent 2x the nv
+    //int nv = k_accum_d.extent(0);
+
+    Kokkos::parallel_for("combine accumulator array", nv, KOKKOS_LAMBDA (const int i) {
+            //std::cout << "copying over " << k_accum_copy(i, accumulator_var::jx, 0) << std::endl;
+        k_accum_d(i, accumulator_var::jx, 0) += k_accum_copy(i, accumulator_var::jx, 0);
+        k_accum_d(i, accumulator_var::jx, 1) += k_accum_copy(i, accumulator_var::jx, 1);
+        k_accum_d(i, accumulator_var::jx, 2) += k_accum_copy(i, accumulator_var::jx, 2);
+        k_accum_d(i, accumulator_var::jx, 3) += k_accum_copy(i, accumulator_var::jx, 3);
+
+        k_accum_d(i, accumulator_var::jy, 0) += k_accum_copy(i, accumulator_var::jy, 0);
+        k_accum_d(i, accumulator_var::jy, 1) += k_accum_copy(i, accumulator_var::jy, 1);
+        k_accum_d(i, accumulator_var::jy, 2) += k_accum_copy(i, accumulator_var::jy, 2);
+        k_accum_d(i, accumulator_var::jy, 3) += k_accum_copy(i, accumulator_var::jy, 3);
+
+        k_accum_d(i, accumulator_var::jz, 0) += k_accum_copy(i, accumulator_var::jz, 0);
+        k_accum_d(i, accumulator_var::jz, 1) += k_accum_copy(i, accumulator_var::jz, 1);
+        k_accum_d(i, accumulator_var::jz, 2) += k_accum_copy(i, accumulator_var::jz, 2);
+        k_accum_d(i, accumulator_var::jz, 3) += k_accum_copy(i, accumulator_var::jz, 3);
+    });
+}
+
+void
 unload_accumulator_array_kokkos(field_array_t* RESTRICT fa,
                                 const accumulator_array_t* RESTRICT aa) {
   if( !fa || !aa || fa->g!=aa->g ) ERROR(( "Bad args" ));

--- a/src/species_advance/species_advance.h
+++ b/src/species_advance/species_advance.h
@@ -305,15 +305,6 @@ void k_accumulate_rhob(
             const float qsp,
             const int nm);
 
-void k_accumulate_rhob_single_cpu(
-            k_field_t& kfield,
-            k_particles_t& kpart,
-            k_particles_i_t& kpart_i,
-            const int i,
-            const grid_t* g,
-            const float qsp
-);
-
 // In hydro_p.c
 
 void
@@ -672,6 +663,7 @@ move_p_kokkos_host_serial(
     //Kokkos::atomic_add(&a[3], v3);
 
     accumulate_j(x,y,z);
+    std::cout << " deposit " << k_accumulators(ii, accumulator_var::jx, 0) << std::endl;
     k_accumulators(ii, accumulator_var::jx, 0) += v0;
     k_accumulators(ii, accumulator_var::jx, 1) += v1;
     k_accumulators(ii, accumulator_var::jx, 2) += v2;

--- a/src/vpic/vpic.cc
+++ b/src/vpic/vpic.cc
@@ -253,6 +253,7 @@ void restore_kokkos(vpic_simulation& simulation)
     new(&accum->k_a_d) k_accumulators_t();
     new(&accum->k_a_h) k_accumulators_t::HostMirror();
     new(&accum->k_a_sa) k_accumulators_sa_t();
+    new(&accum->k_a_d_copy) k_accumulators_t();
 
     std::cout << "make accum of size " << accum->na << std::endl;
     accum->init_kokoks_accum(accum->na);


### PR DESCRIPTION
Data used to be copied from the GPU->CPU and back (CPU->GPU)

This instead bundles up contributions on the CPU, and only does the
CPU->GPU copy

It also decreases the size of the accum arrays, which used to be
oversized to satisfy some power of 2 stuff done in the old pipeline model

This fixes #23