### PR TITLE
WIP: Reduce accum data copy cost (~2x)

### DIFF
--- a/src/boundary/boundary.h
+++ b/src/boundary/boundary.h
@@ -40,7 +40,8 @@ void
 boundary_p_kokkos( particle_bc_t       * RESTRICT pbc_list,
             species_t           * RESTRICT sp_list,
             field_array_t       * RESTRICT fa,
-            accumulator_array_t * RESTRICT aa );
+            accumulator_array_t * RESTRICT aa
+        );
 
 /* In maxwellian_reflux.c */
 

--- a/src/boundary/boundary_p.cc
+++ b/src/boundary/boundary_p.cc
@@ -65,18 +65,6 @@ boundary_p_kokkos(
       )
 {
 
-  // TODO: this doesn't need to be made every time
-  // Make scatter add ON HOST
-  // TODO: hard coding OpenMP here is not good
-  /*
-  Kokkos::Experimental::ScatterView<float
-      *[ACCUMULATOR_VAR_COUNT][ACCUMULATOR_ARRAY_LENGTH], Kokkos::LayoutLeft,
-      Kokkos::OpenMP, Kokkos::Experimental::ScatterSum,
-      Kokkos::Experimental::ScatterDuplicated ,
-      Kokkos::Experimental::ScatterNonAtomic > scatter_add =
-          Kokkos::Experimental::create_scatter_view(aa->k_a_h);
-          */
-
   // Temporary store for local particle injectors
   // FIXME: Ugly static usage
   static particle_injector_t * RESTRICT ALIGNED(16) ci = NULL;
@@ -249,7 +237,7 @@ boundary_p_kokkos(
 
                 // TODO: We could detect this on the GPU side and process is there instead
                   // Not doing that costs us data copies in the fields
-                int i = pm->i;
+                //int i = pm->i;
                 //const auto& kfield_h = fa->k_f_h;
                 const auto& krhob_accum_h = fa->k_f_rhob_accum_h;
                 const auto& kparticle_move_h = sp->k_pc_h;

--- a/src/sf_interface/accumulator_array.cc
+++ b/src/sf_interface/accumulator_array.cc
@@ -1,4 +1,4 @@
-/* 
+/*
  * Written by:
  *   Kevin J. Bowers, Ph.D.
  *   Plasma Physics Group (X-1)
@@ -47,13 +47,13 @@ new_accumulator_array( grid_t * g ) {
   //printf("Making %d copies of accumulator \n",aa_n_pipeline()+1 );
   aa = new accumulator_array_t(
           //(size_t)(aa->n_pipeline+1)*(size_t)aa->stride,
-          (size_t)(aa_n_pipeline()+1)*(size_t)(POW2_CEIL(g->nv,2))
-          //g->nv
+          //(size_t)(aa_n_pipeline()+1)*(size_t)(POW2_CEIL(g->nv,2))
+          g->nv
   );
   aa->n_pipeline = aa_n_pipeline();
   aa->stride     = POW2_CEIL(g->nv,2);
   aa->g          = g;
-  aa->na         = (size_t)(aa->n_pipeline+1)*(size_t)aa->stride;
+  //aa->na         = (size_t)(aa->n_pipeline+1)*(size_t)aa->stride;
   MALLOC_ALIGNED( aa->a, aa->na, 128 );
   CLEAR( aa->a, aa->na);
   REGISTER_OBJECT( aa, checkpt_accumulator_array, restore_accumulator_array,

--- a/src/sf_interface/accumulator_array.cc
+++ b/src/sf_interface/accumulator_array.cc
@@ -47,7 +47,8 @@ new_accumulator_array( grid_t * g ) {
   //printf("Making %d copies of accumulator \n",aa_n_pipeline()+1 );
   aa = new accumulator_array_t(
           //(size_t)(aa->n_pipeline+1)*(size_t)aa->stride,
-          (size_t)(aa_n_pipeline()+1)*(size_t)(POW2_CEIL(g->nv,2))
+          //(size_t)(aa_n_pipeline()+1)*(size_t)(POW2_CEIL(g->nv,2))
+          g->nv
   );
   aa->n_pipeline = aa_n_pipeline();
   aa->stride     = POW2_CEIL(g->nv,2);

--- a/src/sf_interface/accumulator_array.cc
+++ b/src/sf_interface/accumulator_array.cc
@@ -47,8 +47,8 @@ new_accumulator_array( grid_t * g ) {
   //printf("Making %d copies of accumulator \n",aa_n_pipeline()+1 );
   aa = new accumulator_array_t(
           //(size_t)(aa->n_pipeline+1)*(size_t)aa->stride,
-          //(size_t)(aa_n_pipeline()+1)*(size_t)(POW2_CEIL(g->nv,2))
-          g->nv
+          (size_t)(aa_n_pipeline()+1)*(size_t)(POW2_CEIL(g->nv,2))
+          //g->nv
   );
   aa->n_pipeline = aa_n_pipeline();
   aa->stride     = POW2_CEIL(g->nv,2);

--- a/src/sf_interface/clear_accumulators.cc
+++ b/src/sf_interface/clear_accumulators.cc
@@ -43,9 +43,9 @@ clear_accumulator_array_kokkos(accumulator_array_t* RESTRICT aa) {
     const int nx = g->nx, ny = g->ny, nz = g->nz;
     const k_accumulators_t& k_accum = aa->k_a_d;
 
-    Kokkos::MDRangePolicy<Kokkos::Rank<5>> policy({1, 1, 1, 0, 0}, {nz+2, ny+2, nx+2, 3, 4});
-    Kokkos::parallel_for("clear accumulators", policy, KOKKOS_LAMBDA(const int z, const int y, const int x, const int j, const int w) {
-        k_accum(VOXEL(x,y,z,nx,ny,nz), j, w) = 0.0f;
-    });
-
+    Kokkos::deep_copy(k_accum, 0.0f);
+    //Kokkos::MDRangePolicy<Kokkos::Rank<5>> policy({1, 1, 1, 0, 0}, {nz+2, ny+2, nx+2, 3, 4});
+    //Kokkos::parallel_for("clear accumulators", policy, KOKKOS_LAMBDA(const int z, const int y, const int x, const int j, const int w) {
+        //k_accum(VOXEL(x,y,z,nx,ny,nz), j, w) = 0.0f;
+    //});
 }

--- a/src/sf_interface/sf_interface.h
+++ b/src/sf_interface/sf_interface.h
@@ -107,7 +107,7 @@ typedef struct accumulator_array {
       na = _na;
 
       k_a_d = k_accumulators_t("k_accumulators", _na);
-      k_a_d = k_accumulators_t("k_accumulators_copy", _na);
+      k_a_d_copy = k_accumulators_t("k_accumulators_copy", _na);
       k_a_sa = Kokkos::Experimental::create_scatter_view(k_a_d);
       k_a_h  = Kokkos::create_mirror_view(k_a_d);
   }

--- a/src/sf_interface/sf_interface.h
+++ b/src/sf_interface/sf_interface.h
@@ -95,6 +95,7 @@ typedef struct accumulator_array {
   k_accumulators_t::HostMirror k_a_h;
   k_accumulators_sa_t k_a_sa;
   //k_accumulators_sah_t k_a_sah;
+  k_accumulators_t k_a_d_copy;
 
   accumulator_array(int _na)
   {
@@ -106,16 +107,9 @@ typedef struct accumulator_array {
       na = _na;
 
       k_a_d = k_accumulators_t("k_accumulators", _na);
-        //printf("Making accumulator of size %d", na);
-        // TODO: kokkos can deduce these
+      k_a_d = k_accumulators_t("k_accumulators_copy", _na);
       k_a_sa = Kokkos::Experimental::create_scatter_view(k_a_d);
-        //<Kokkos::Experimental::ScatterSum,
-         //KOKKOS_SCATTER_DUPLICATED,
-         //KOKKOS_SCATTER_ATOMIC>(k_a_d);
       k_a_h  = Kokkos::create_mirror_view(k_a_d);
-
-      //k_a_sah = Kokkos::Experimental::create_scatter_view(k_a_h);
-      //printf("k_a_h size = %d \n", k_a_h.size() );
   }
 
 
@@ -170,6 +164,9 @@ unload_accumulator_array( /**/  field_array_t       * RESTRICT fa,
 void
 unload_accumulator_array_kokkos( /**/  field_array_t       * RESTRICT fa,
                           const accumulator_array_t * RESTRICT aa );
+
+void
+combine_accumulators( accumulator_array_t * RESTRICT aa );
 
 /*****************************************************************************/
 

--- a/src/sf_interface/unload_accumulator.cc
+++ b/src/sf_interface/unload_accumulator.cc
@@ -15,13 +15,13 @@ unload_accumulator_pipeline( unload_accumulator_pipeline_args_t * args,
                              int n_pipeline ) {
   field_t             * ALIGNED(128) f = args->f;
   const accumulator_t * ALIGNED(128) a = args->a;
-  
+
   const accumulator_t * ALIGNED(16) a0;
   const accumulator_t * ALIGNED(16) ax,  * ALIGNED(16) ay,  * ALIGNED(16) az;
   const accumulator_t * ALIGNED(16) ayz, * ALIGNED(16) azx, * ALIGNED(16) axy;
   field_t * ALIGNED(16) f0;
   int x, y, z, n_voxel;
-  
+
   const int nx = args->nx;
   const int ny = args->ny;
   const int nz = args->nz;
@@ -31,7 +31,7 @@ unload_accumulator_pipeline( unload_accumulator_pipeline_args_t * args,
   const float cz = args->cz;
 
   // Process the voxels assigned to this pipeline
-  
+
   if( pipeline_rank==n_pipeline ) return; // No need for straggler cleanup
   DISTRIBUTE_VOXELS( 1,nx+1, 1,ny+1, 1,nz+1, 1,
                      pipeline_rank, n_pipeline, x, y, z, n_voxel );
@@ -140,20 +140,20 @@ unload_accumulator_array_kokkos(field_array_t* RESTRICT fa,
         int ayz = VOXEL(1, y-1, z-1, nx, ny, nz) + x-1;
         int azx = VOXEL(0, y, z-1, nx, ny, nz) + x-1;
         int axy = VOXEL(0, y-1, z, nx, ny, nz) + x-1;
-        k_field(f0, field_var::jfx) += cx*( k_accum(a0, accumulator_var::jx, 0) + 
-                                            k_accum(ay, accumulator_var::jx, 1) + 
-                                            k_accum(az, accumulator_var::jx, 2) + 
+        k_field(f0, field_var::jfx) += cx*( k_accum(a0, accumulator_var::jx, 0) +
+                                            k_accum(ay, accumulator_var::jx, 1) +
+                                            k_accum(az, accumulator_var::jx, 2) +
                                             k_accum(ayz, accumulator_var::jx, 3) );
-        k_field(f0, field_var::jfy) += cy*( k_accum(a0, accumulator_var::jy, 0) + 
-                                            k_accum(az, accumulator_var::jy, 1) + 
-                                            k_accum(ax, accumulator_var::jy, 2) + 
+        k_field(f0, field_var::jfy) += cy*( k_accum(a0, accumulator_var::jy, 0) +
+                                            k_accum(az, accumulator_var::jy, 1) +
+                                            k_accum(ax, accumulator_var::jy, 2) +
                                             k_accum(azx, accumulator_var::jy, 3) );
-        k_field(f0, field_var::jfz) += cz*( k_accum(a0, accumulator_var::jz, 0) + 
-                                            k_accum(ax, accumulator_var::jz, 1) + 
-                                            k_accum(ay, accumulator_var::jz, 2) + 
+        k_field(f0, field_var::jfz) += cz*( k_accum(a0, accumulator_var::jz, 0) +
+                                            k_accum(ax, accumulator_var::jz, 1) +
+                                            k_accum(ay, accumulator_var::jz, 2) +
                                             k_accum(axy, accumulator_var::jz, 3) );
     });
-/*    
+/*
     Kokkos::parallel_for("unload_accumulator_array", KOKKOS_TEAM_POLICY_DEVICE(nz+1, Kokkos::AUTO),
     KOKKOS_LAMBDA(const KOKKOS_TEAM_POLICY_DEVICE::member_type& team_member) {
         const size_t z = team_member.league_rank() + 1;
@@ -169,17 +169,17 @@ unload_accumulator_array_kokkos(field_array_t* RESTRICT fa,
                 int ayz = VOXEL(1, y-1, z-1, nx, ny, nz) + i;
                 int azx = VOXEL(0, y, z-1, nx, ny, nz) + i;
                 int axy = VOXEL(0, y-1, z, nx, ny, nz) + i;
-                k_field(f0, field_var::jfx) += cx*( k_accum(a0, accumulator_var::jx, 0) + 
-                                                    k_accum(ay, accumulator_var::jx, 1) + 
-                                                    k_accum(az, accumulator_var::jx, 2) + 
+                k_field(f0, field_var::jfx) += cx*( k_accum(a0, accumulator_var::jx, 0) +
+                                                    k_accum(ay, accumulator_var::jx, 1) +
+                                                    k_accum(az, accumulator_var::jx, 2) +
                                                     k_accum(ayz, accumulator_var::jx, 3) );
-                k_field(f0, field_var::jfy) += cy*( k_accum(a0, accumulator_var::jy, 0) + 
-                                                    k_accum(az, accumulator_var::jy, 1) + 
-                                                    k_accum(ax, accumulator_var::jy, 2) + 
+                k_field(f0, field_var::jfy) += cy*( k_accum(a0, accumulator_var::jy, 0) +
+                                                    k_accum(az, accumulator_var::jy, 1) +
+                                                    k_accum(ax, accumulator_var::jy, 2) +
                                                     k_accum(azx, accumulator_var::jy, 3) );
-                k_field(f0, field_var::jfz) += cz*( k_accum(a0, accumulator_var::jz, 0) + 
-                                                    k_accum(ax, accumulator_var::jz, 1) + 
-                                                    k_accum(ay, accumulator_var::jz, 2) + 
+                k_field(f0, field_var::jfz) += cz*( k_accum(a0, accumulator_var::jz, 0) +
+                                                    k_accum(ax, accumulator_var::jz, 1) +
+                                                    k_accum(ay, accumulator_var::jz, 2) +
                                                     k_accum(axy, accumulator_var::jz, 3) );
             });
         });
@@ -190,18 +190,17 @@ unload_accumulator_array_kokkos(field_array_t* RESTRICT fa,
 void
 combine_accumulators(accumulator_array_t* RESTRICT aa)
 {
-    // TODO: this is likely faster with a 3d policy
+    // TODO: this is likely faster with a 3d policy?
     //Kokkos::MDRangePolicy<Kokkos::Rank<3>> unload_policy({1, 1, 1}, {nz+2, ny+2, nx+2});
     k_accumulators_t& k_accum_d = aa->k_a_d;
     k_accumulators_t& k_accum_copy = aa->k_a_d_copy;
 
     auto& k_accum_h = aa->k_a_h;
+
     Kokkos::deep_copy(k_accum_copy, k_accum_h);
 
-    int nv = aa->g->nv;
-    //std::cout << " nv " << nv << " size " << k_accum_d.size() << " extent " << k_accum_d.extent(0) << std::endl;
-    // TODO: why is extent 2x the nv
-    //int nv = k_accum_d.extent(0);
+    //int nv = aa->g->nv;
+    int nv = k_accum_d.extent(0);
 
     Kokkos::parallel_for("combine accumulator array", nv, KOKKOS_LAMBDA (const int i) {
             //std::cout << "copying over " << k_accum_copy(i, accumulator_var::jx, 0) << std::endl;

--- a/src/vpic/advance.cc
+++ b/src/vpic/advance.cc
@@ -45,10 +45,6 @@ int vpic_simulation::advance(void)
     // TIC clear_accumulator_array( accumulator_array ); TOC( clear_accumulators, 1 );
     TIC clear_accumulator_array_kokkos( accumulator_array ); TOC( clear_accumulators, 1 );
   }
-  //  KOKKOS_TIC();
-  //  KOKKOS_COPY_ACCUMULATOR_MEM_TO_HOST(accumulator_array);
-  //  KOKKOS_TOC( ACCUMULATOR_DATA_MOVEMENT, 1);
-
   // Note: Particles should not have moved since the last performance sort
   // when calling collision operators.
   // FIXME: Technically, this placement of the collision operators only
@@ -63,14 +59,6 @@ int vpic_simulation::advance(void)
 
   //TIC user_particle_collisions(); TOC( user_particle_collisions, 1 );
 
-  //  KOKKOS_TIC(); // Time this data movement
-  //  KOKKOS_COPY_ACCUMULATOR_MEM_TO_DEVICE(accumulator_array);
-  //  KOKKOS_TOC( ACCUMULATOR_DATA_MOVEMENT, 1);
-  //  KOKKOS_TIC();
-  //  KOKKOS_COPY_INTERPOLATOR_MEM_TO_DEVICE(interpolator_array);
-  //  KOKKOS_TOC( INTERPOLATOR_DATA_MOVEMENT, 1);
-  //  KOKKOS_COPY_PARTICLE_MEM_TO_DEVICE();
-
   // DEVICE function - Touches particles, particle movers, accumulators, interpolators
   LIST_FOR_EACH( sp, species_list )
   {
@@ -82,17 +70,6 @@ int vpic_simulation::advance(void)
   Kokkos::Experimental::contribute(accumulator_array->k_a_d, accumulator_array->k_a_sa);
   accumulator_array->k_a_sa.reset_except(accumulator_array->k_a_d);
   KOKKOS_TOC( accumulator_contributions, 1);
-
-  //  KOKKOS_TIC(); // Time this data movement
-  //  KOKKOS_COPY_ACCUMULATOR_MEM_TO_HOST(accumulator_array);
-  //  KOKKOS_TOC( ACCUMULATOR_DATA_MOVEMENT, 1);
-  //  KOKKOS_TIC()
-  //  KOKKOS_COPY_INTERPOLATOR_MEM_TO_HOST(interpolator_array);
-  //  KOKKOS_TOC( INTERPOLATOR_DATA_MOVEMENT, 1);
-
-  //  KOKKOS_TIC()
-  //  KOKKOS_COPY_INTERPOLATOR_MEM_TO_HOST(interpolator_array);
-  //  KOKKOS_TOC( INTERPOLATOR_DATA_MOVEMENT, 1);
 
   KOKKOS_TIC(); // Time this data movement
   // TODO: make this into a function
@@ -167,10 +144,6 @@ int vpic_simulation::advance(void)
   // This should be after the emission and injection to allow for the
   // possibility of thread parallelizing these operations
 
-  //  KOKKOS_TIC();
-  //  KOKKOS_COPY_ACCUMULATOR_MEM_TO_DEVICE();
-  //  KOKKOS_TOC( ACCUMULATOR_DATA_MOVEMENT, 1);
-
   // HOST
   // Touches accumulator memory
   //  if( species_list )
@@ -182,10 +155,7 @@ int vpic_simulation::advance(void)
   // guard lists. Particles that absorbed are added to rhob (using a corrected
   // local accumulation).
 
-  // This should mean the kokkos accum data is up to date
-  //KOKKOS_TIC();
-  //KOKKOS_COPY_ACCUMULATOR_MEM_TO_DEVICE(accumulator_array);
-  //KOKKOS_TOC( ACCUMULATOR_DATA_MOVEMENT, 1);
+  // This means the kokkos accum data is up to date
   KOKKOS_TIC(); // Time this data movement
   Kokkos::deep_copy(accumulator_array->k_a_h, accumulator_array->k_a_d);
   KOKKOS_TOC( ACCUMULATOR_DATA_MOVEMENT, 1);

--- a/src/vpic/advance.cc
+++ b/src/vpic/advance.cc
@@ -206,7 +206,7 @@ int vpic_simulation::advance(void)
   //accumulator_array->k_a_sa.reset_except(accumulator_array->k_a_h);
 
   // If we didn't accumulate in place (as in the GPU case), do so
-  if (! accumulate_in_place )
+  if ( accumulate_in_place == false)
   {
       // Update device so we can pull it all the way back to the host
       KOKKOS_TIC(); // Time this data movement

--- a/src/vpic/vpic.cc
+++ b/src/vpic/vpic.cc
@@ -251,6 +251,7 @@ void restore_kokkos(vpic_simulation& simulation)
     //int num_accum = old_accum->na;
 
     new(&accum->k_a_d) k_accumulators_t();
+    new(&accum->k_a_d_copy) k_accumulators_t();
     new(&accum->k_a_h) k_accumulators_t::HostMirror();
     new(&accum->k_a_sa) k_accumulators_sa_t();
 


### PR DESCRIPTION
Data used to be copied from the GPU->CPU and back (CPU->GPU)

This instead bundles up contributions on the CPU, and only does the
CPU->GPU copy

It also decreases the size of the accum arrays, which used to be
oversized to satisfy some power of 2 stuff done in the old pipeline model

This fixes #23