### PR TITLE
Stop accumulate_rho_p from printing

### DIFF
--- a/src/species_advance/standard/rho_p.cc
+++ b/src/species_advance/standard/rho_p.cc
@@ -133,7 +133,6 @@ accumulate_rhob( field_t          * RESTRICT ALIGNED(128) f,
         const float                              qsp ) {
 # if 1
 
-    std::cout << "accumulate rhob" << std::endl;
     // See note in rhof for why this variant is used.
     float w0 = p->dx, w1 = p->dy, w2, w3, w4, w5, w6, w7, dz = p->dz;
     int v = p->i, x, y, z, sy = g->sy, sz = g->sz;


### PR DESCRIPTION
Legacy code I have uses `accumulate_rhob` and right now it swamps the logs.