### PR TITLE
Fixed issue #64 where macros in a deck's path would be expanded by the

### DIFF
--- a/deck/wrapper.cc
+++ b/deck/wrapper.cc
@@ -1,4 +1,6 @@
 #include "wrapper.h"
 
 // Include the users input deck
-#include EXPAND_AND_STRINGIFY(INPUT_DECK)
+#define EMPTY()
+#define shallow(s) s EMPTY()
+#include EXPAND_AND_STRINGIFY(shallow(INPUT_DECK))


### PR DESCRIPTION
preprocessor and compilation would fail.  Now, via some preprocessor
magic, the EXPAND_AND STRINGIFY is shallow.