### PR TITLE
Fix vectorization

### DIFF
--- a/src/species_advance/standard/advance_p.cc
+++ b/src/species_advance/standard/advance_p.cc
@@ -202,12 +202,20 @@ void simd_load_interpolator_var(float* v0, const int ii, const k_interpolator_t&
 template<int N>
 KOKKOS_INLINE_FUNCTION
 void unrolled_simd_load(float* vals, const int* ii, const k_interpolator_t& k_interp, int len) {
-  simd_load_interpolator_var(vals+(N-1)*18, ii[N-1], k_interp, len);
   unrolled_simd_load<N-1>(vals, ii, k_interp, len);
+  simd_load_interpolator_var(vals+(N-1)*18, ii[N-1], k_interp, len);
 }
 template<>
 KOKKOS_INLINE_FUNCTION
 void unrolled_simd_load<0>(float* vals, const int* ii, const k_interpolator_t& k_interp, int len) {}
+
+// Non forced unrolled version. Potentially less performance than the template version
+// This will work with arbitrary number of particles rather than having to use a multiple of the number of simd lanes
+void unrolled_simd_load(float* vals, const int* ii, const k_interpolator_t& k_interp, int num_var, int num_part) {
+  for(int i=0; i<num_part; i++) {
+    simd_load_interpolator_var(vals+i*num_var, ii[i], k_interp, num_var);
+  }
+}
 
 // Load interpolators
 template<int NumLanes>
@@ -270,15 +278,16 @@ void load_interpolators(
       fcbz[i]      = vals[16];
       fdcbzdz[i]   = vals[17];
     }
-  } else if(NumLanes == num_part) {
+  } else {
 
     // Efficient vectorized load
     float vals[18*NumLanes];
-    unrolled_simd_load<NumLanes>(vals, ii, k_interp, 18);
+    unrolled_simd_load(vals, ii, k_interp, 18, num_part);
+//    unrolled_simd_load<NumLanes>(vals, ii, k_interp, 18);
 
     // Essentially a transpose
     #pragma omp simd
-    for(int i=0; i<NumLanes; i++) {
+    for(int i=0; i<num_part; i++) {
       fex[i]       = vals[18*i];
       fdexdy[i]    = vals[1+18*i];
       fdexdz[i]    = vals[2+18*i];
@@ -297,28 +306,6 @@ void load_interpolators(
       fdcbydy[i]   = vals[15+18*i];
       fcbz[i]      = vals[16+18*i];
       fdcbzdz[i]   = vals[17+18*i];
-    }
-  } else {
-    for(int lane=0; lane<num_part; lane++) {
-      // Load interpolators
-      fex[LANE]       = k_interp(ii[LANE], interpolator_var::ex);     
-      fdexdy[LANE]    = k_interp(ii[LANE], interpolator_var::dexdy);  
-      fdexdz[LANE]    = k_interp(ii[LANE], interpolator_var::dexdz);  
-      fd2exdydz[LANE] = k_interp(ii[LANE], interpolator_var::d2exdydz);
-      fey[LANE]       = k_interp(ii[LANE], interpolator_var::ey);     
-      fdeydz[LANE]    = k_interp(ii[LANE], interpolator_var::deydz);  
-      fdeydx[LANE]    = k_interp(ii[LANE], interpolator_var::deydx);  
-      fd2eydzdx[LANE] = k_interp(ii[LANE], interpolator_var::d2eydzdx);
-      fez[LANE]       = k_interp(ii[LANE], interpolator_var::ez);     
-      fdezdx[LANE]    = k_interp(ii[LANE], interpolator_var::dezdx);  
-      fdezdy[LANE]    = k_interp(ii[LANE], interpolator_var::dezdy);  
-      fd2ezdxdy[LANE] = k_interp(ii[LANE], interpolator_var::d2ezdxdy);
-      fcbx[LANE]      = k_interp(ii[LANE], interpolator_var::cbx);    
-      fdcbxdx[LANE]   = k_interp(ii[LANE], interpolator_var::dcbxdx); 
-      fcby[LANE]      = k_interp(ii[LANE], interpolator_var::cby);    
-      fdcbydy[LANE]   = k_interp(ii[LANE], interpolator_var::dcbydy); 
-      fcbz[LANE]      = k_interp(ii[LANE], interpolator_var::cbz);    
-      fdcbzdz[LANE]   = k_interp(ii[LANE], interpolator_var::dcbzdz); 
     }
   }
 #else


### PR DESCRIPTION
Fix for bug in vectorized advance_p kernel. Code tries to load interpolators using SIMD. Bug was triggered when it would try to load the interpolators for the last particles in the list. Since the last few particles weren't exactly the number of simd lanes the code would try to load values outside the interpolator array and trigger a segmentation fault. 

The pull request fixes the problem by loading the last particles correctly. There is a small performance degradation (~1%) since the changes prevent the use of the template code that unrolls the interpolator loading loop. This is unavoidable unless particles are always moved in exact multiples of the number of simd lanes.