### PR TITLE
Update kokkos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Build kokkos
       working-directory: kokkos
       run: |
-        cmake -B build -DCMAKE_INSTALL_PREFIX=$HOME/kokkos -DKokkos_CXX_STANDARD=17
+        cmake -B build -DCMAKE_INSTALL_PREFIX=$HOME/kokkos -DCMAKE_CXX_STANDARD=17
         cmake --build build --parallel 2
         cmake --install build
     #- uses: actions/checkout@v2

--- a/src/field_advance/standard/energy_f.cc
+++ b/src/field_advance/standard/energy_f.cc
@@ -175,7 +175,7 @@ struct field_reduce {
     }
 
     KOKKOS_INLINE_FUNCTION void
-    join(volatile value_type dst, const volatile value_type src) const {
+    join(value_type dst, const value_type src) const {
         for(size_type i = 0; i < 6; i++) {
             dst[i] += src[i];
         }

--- a/src/field_advance/standard/vacuum_energy_f.cc
+++ b/src/field_advance/standard/vacuum_energy_f.cc
@@ -153,7 +153,7 @@ struct field_reduce {
     }
 
     KOKKOS_INLINE_FUNCTION void
-    join(volatile value_type dst, const volatile value_type src) const {
+    join(value_type dst, const value_type src) const {
         for(size_type i = 0; i < 6; i++) {
             dst[i] += src[i];
         }


### PR DESCRIPTION
This commit removes volatile type qualifiers from the field energy reducer functors. Recent versions of Kokkos no longer allow volatile parameters. 