### PR TITLE
Fix for running with AMD GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,11 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
   set(VPIC_CXX_FLAGS "${VPIC_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 endif("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
 
+# Add Release flags to VPIC_CXX_FLAGS
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+  set(VPIC_CXX_FLAGS "${VPIC_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}")
+endif("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+
 string(REPLACE ";" " " string_libraries "${MPI_CXX_LIBRARIES} ${MPI_C_LIBRARIES}")
 set(VPIC_CXX_LIBRARIES "${string_libraries}")
 

--- a/src/species_advance/species_advance.h
+++ b/src/species_advance/species_advance.h
@@ -606,13 +606,6 @@ move_p_kokkos(
       // momentum and remaining displacement and keep moving the
       // particle.
       k_particles(pi, particle_var::ux + axis) = -k_particles(pi, particle_var::ux + axis);
-
-      // TODO: make this safer
-      //(&(pm->dispx))[axis] = -(&(pm->dispx))[axis];
-      //k_local_particle_movers(0, particle_mover_var::dispx + axis) = -k_local_particle_movers(0, particle_mover_var::dispx + axis);
-      // TODO: replace this, it's horrible
-      //(&(pm->dispx))[axis] = -(&(pm->dispx))[axis];
-
       // Clearer and works with AMD GPUs
       float* disp = static_cast<float*>(&(pm->dispx));
       disp[axis] = -disp[axis];
@@ -837,13 +830,9 @@ move_p_kokkos_host_serial(
       // momentum and remaining displacement and keep moving the
       // particle.
       k_particles(pi, particle_var::ux + axis) = -k_particles(pi, particle_var::ux + axis);
-
-      // TODO: make this safer
-      //(&(pm->dispx))[axis] = -(&(pm->dispx))[axis];
-      //k_local_particle_movers(0, particle_mover_var::dispx + axis) = -k_local_particle_movers(0, particle_mover_var::dispx + axis);
-      // TODO: replace this, it's horrible
-      (&(pm->dispx))[axis] = -(&(pm->dispx))[axis];
-
+      // Clearer and works with AMD GPUs
+      float* disp = static_cast<float*>(&(pm->dispx));
+      disp[axis] = -disp[axis];
 
       continue;
     }

--- a/src/species_advance/species_advance.h
+++ b/src/species_advance/species_advance.h
@@ -611,8 +611,11 @@ move_p_kokkos(
       //(&(pm->dispx))[axis] = -(&(pm->dispx))[axis];
       //k_local_particle_movers(0, particle_mover_var::dispx + axis) = -k_local_particle_movers(0, particle_mover_var::dispx + axis);
       // TODO: replace this, it's horrible
-      (&(pm->dispx))[axis] = -(&(pm->dispx))[axis];
+      //(&(pm->dispx))[axis] = -(&(pm->dispx))[axis];
 
+      // Clearer and works with AMD GPUs
+      float* disp = static_cast<float*>(&(pm->dispx));
+      disp[axis] = -disp[axis];
 
       continue;
     }


### PR DESCRIPTION
AMD GPUs can get stuck in an infinite loop due to the reflect particles handler in move_p. For some reason ROCm is not correctly negating the particle movers displacement which leads to an infinite loop where the position of the particle never gets updated. 

This pull request fixes it by explicitly casting the pointer to the displacement to a float pointer. There is no significant performance impact.

Also adjusts the CMakelists to correctly pass Release build flags to the deck building script.