### PR TITLE
Updated hydro array copy_to_host function to fix off-by-one copy error

### DIFF
--- a/src/sf_interface/hydro_array.cc
+++ b/src/sf_interface/hydro_array.cc
@@ -522,7 +522,7 @@ hydro_array_t::copy_to_host() {
 
   //for(int i=0; i<hydro_array->k_h_h.extent(0); i++) {
   Kokkos::parallel_for("copy hydro to legacy array",
-    host_execution_policy(0, k_h_h.extent(0) - 1) ,
+    host_execution_policy(0, k_h_h.extent(0)) ,
     KOKKOS_LAMBDA (int i) {
     h_l[i].jx = k_h(i, hydro_var::jx);
     h_l[i].jy = k_h(i, hydro_var::jy);


### PR DESCRIPTION
Fixed an off-by-one error present in the Hydro Array's copy_to_host function. This error was causing exactly one cell of hydro data to not be correctly copied, which was causing the opposite cells data to not be computed correctly during data export.