### PR TITLE
[hvpic-k-devel] fix hydro accum NaNs w/VARIABLE_CHARGE enabled

### DIFF
--- a/src/species_advance/standard/hydro_p.cc
+++ b/src/species_advance/standard/hydro_p.cc
@@ -342,7 +342,7 @@ accumulate_hydro_p_kokkos(
 #ifdef VARIABLE_CHARGE
     float qp = k_particles(p_index, particle_var::qp);
     float qdt_2mc = qp*dt_2mc;
-    float qdt_4mc2 = qp*qdt_4mc2;
+    float qdt_4mc2 = qp*dt_4mc2;
 #endif
     int ii = k_particles_i(p_index);
 


### PR DESCRIPTION
Fix PCAI test failing on NERSC Perlmutter, got NaN aniso data derived from pxx,pyy,pzz in accumulate_hydro_p_kokkos(...), due to uninit variable used in particle half-timestep push