### PR TITLE
[hvpic-k-devel] hydro dump stencils NGP shape

### DIFF
--- a/src/species_advance/standard/hydro_p.cc
+++ b/src/species_advance/standard/hydro_p.cc
@@ -29,10 +29,10 @@ accumulate_hydro_p( hydro_array_t              * RESTRICT ha,
   /**/  hydro_t        * RESTRICT ALIGNED(128) h;
   const particle_t     * RESTRICT ALIGNED(128) p;
   const interpolator_t * RESTRICT ALIGNED(128) f;
-  float c, qsp, mspc, qdt_2mc, qdt_4mc2, r8V;
+  float c, qsp, msp, qdt_2mc, qdt_4mc, r8V;
   int np, stride_10, stride_21, stride_43;
 
-  float dx, dy, dz, ux, uy, uz, w, vx, vy, vz, ke_mc;
+  float dx, dy, dz, ux, uy, uz, w;
   float w0, w1, w2, w3, w4, w5, w6, w7, t;
   int i, n;
 
@@ -45,9 +45,12 @@ accumulate_hydro_p( hydro_array_t              * RESTRICT ha,
 
   c        = sp->g->cvac;
   qsp      = sp->q;
-  mspc     = sp->m*c;
-  qdt_2mc  = (qsp*sp->g->dt)/(2*mspc);
-  qdt_4mc2 = qdt_2mc / (2*c);
+  //mspc     = sp->m*c;                   // rel push
+  //qdt_2mc  = (qsp*sp->g->dt)/(2*mspc);
+  //qdt_4mc2 = qdt_2mc / (2*c);
+  msp      = sp->m;                       // non-rel push
+  qdt_2mc  = (qsp*sp->g->dt)/(2*msp*c);
+  qdt_4mc  = qdt_2mc / 2;
   r8V      = sp->g->r8V;
 
   np        = sp->np;
@@ -83,11 +86,12 @@ accumulate_hydro_p( hydro_array_t              * RESTRICT ha,
     // Boris rotation - curl scalars (0.5 in v0 for half rotate) and
     // kinetic energy computation. Note: gamma-1 = |u|^2 / (gamma+1)
     // is the numerically accurate way to compute gamma-1
-    ke_mc = ux*ux + uy*uy + uz*uz; // ke_mc = |u|^2 (invariant)
-    vz = 1;//sqrt(1+ke_mc);            // vz = gamma    (invariant)
-    ke_mc *= c/(vz+1);             // ke_mc = c|u|^2/(gamma+1) = c*(gamma-1)
-    vz = c/vz;                     // vz = c/gamma
-    w0 = qdt_4mc2*vz;
+    //ke_mc = ux*ux + uy*uy + uz*uz; // ke_mc = |u|^2 (invariant)
+    //vz = 1;//sqrt(1+ke_mc);            // vz = gamma    (invariant)
+    //ke_mc *= c/(vz+1);             // ke_mc = c|u|^2/(gamma+1) = c*(gamma-1)
+    //vz = c/vz;                     // vz = c/gamma
+    //w0 = qdt_4mc2*vz;
+    w0 = qdt_4mc;  // non-rel push
     w1 = w5*w5 + w6*w6 + w7*w7;    // |cB|^2
     w2 = w0*w0*w1;
     w3 = w0*(1+(1./3.)*w2*(1+0.4*w2));
@@ -103,10 +107,13 @@ accumulate_hydro_p( hydro_array_t              * RESTRICT ha,
     uy += w4*( w2*w5 - w0*w7 );
     uz += w4*( w0*w6 - w1*w5 );
 
-    // Compute physical velocities
-    vx  = ux*vz;
-    vy  = uy*vz;
-    vz *= uz;
+    // Compute physical three-velocities
+    //vx  = ux*vz;  // rel push
+    //vy  = uy*vz;
+    //vz *= uz;
+    ux *= c;        // non-rel push
+    uy *= c;
+    uz *= c;
 
     // Compute the trilinear coefficients
     w0  = r8V*w;    // w0 = (1/8)(w/V)
@@ -130,27 +137,49 @@ accumulate_hydro_p( hydro_array_t              * RESTRICT ha,
     w2 *= dz;       // w2 = (1/8)(w/V)(1-x)(1+y)(1-z) = (w/V) trilin_6 *Done
     w3 *= dz;       // w3 = (1/8)(w/V)(1+x)(1+y)(1-z) = (w/V) trilin_7 *Done
 
-    // Accumulate the hydro fields
+    // Accumulate the hydro fields - relativistic version
+//#   define ACCUM_HYDRO( wn)                             \
+//    t  = qsp*wn;        /* t  = (qsp w/V) trilin_n */   \
+//    h[i].jx  += t*vx;                                   \
+//    h[i].jy  += t*vy;                                   \
+//    h[i].jz  += t*vz;                                   \
+//    h[i].rho += t;                                      \
+//    t  = mspc*wn;       /* t = (msp c w/V) trilin_n */  \
+//    dx = t*ux;          /* dx = (px w/V) trilin_n */    \
+//    dy = t*uy;                                          \
+//    dz = t*uz;                                          \
+//    h[i].px  += dx;                                     \
+//    h[i].py  += dy;                                     \
+//    h[i].pz  += dz;                                     \
+//    h[i].ke  += t*ke_mc;                                \
+//    h[i].txx += dx*vx;                                  \
+//    h[i].tyy += dy*vy;                                  \
+//    h[i].tzz += dz*vz;                                  \
+//    h[i].tyz += dy*vz;                                  \
+//    h[i].tzx += dz*vx;                                  \
+//    h[i].txy += dx*vy
+
+    // Accumulate the hydro fields - non-relativistic version
 #   define ACCUM_HYDRO( wn)                             \
     t  = qsp*wn;        /* t  = (qsp w/V) trilin_n */   \
-    h[i].jx  += t*vx;                                   \
-    h[i].jy  += t*vy;                                   \
-    h[i].jz  += t*vz;                                   \
+    h[i].jx  += t*ux;                                   \
+    h[i].jy  += t*uy;                                   \
+    h[i].jz  += t*uz;                                   \
     h[i].rho += t;                                      \
-    t  = mspc*wn;       /* t = (msp c w/V) trilin_n */  \
+    t  = msp*wn;        /* t = (msp w/V) trilin_n */    \
     dx = t*ux;          /* dx = (px w/V) trilin_n */    \
     dy = t*uy;                                          \
     dz = t*uz;                                          \
     h[i].px  += dx;                                     \
     h[i].py  += dy;                                     \
     h[i].pz  += dz;                                     \
-    h[i].rho_m  += t; /* Prev. was *ke_mc; */		\
-    h[i].txx += dx*vx;                                  \
-    h[i].tyy += dy*vy;                                  \
-    h[i].tzz += dz*vz;                                  \
-    h[i].tyz += dy*vz;                                  \
-    h[i].tzx += dz*vx;                                  \
-    h[i].txy += dx*vy
+    h[i].rho_m  += t; /* Prev. was *ke_mc; */           \
+    h[i].txx += dx*ux;                                  \
+    h[i].tyy += dy*uy;                                  \
+    h[i].tzz += dz*uz;                                  \
+    h[i].tyz += dy*uz;                                  \
+    h[i].tzx += dz*ux;                                  \
+    h[i].txy += dx*uy
 
     /**/            ACCUM_HYDRO(w0); // Cell i,j,k
     i += stride_10; ACCUM_HYDRO(w1); // Cell i+1,j,k
@@ -281,9 +310,9 @@ accumulate_hydro_p_kokkos(
   k_hydro_sv_t k_hydro_sv = Kokkos::Experimental::create_scatter_view(k_hydro);
 
 #ifdef VARIABLE_CHARGE
-  float c, qsp, mspc, dt_2mc, dt_4mc2, r8V;
+  float c, qsp, msp, dt_2mc, dt_4mc, r8V;
 #else
-  float c, qsp, mspc, qdt_2mc, qdt_4mc2, r8V;
+  float c, qsp, msp, qdt_2mc, qdt_4mc, r8V;
 #endif
   //int np, stride_10, stride_21, stride_43;
 
@@ -299,10 +328,13 @@ accumulate_hydro_p_kokkos(
 
   c        = sp->g->cvac;
   qsp      = sp->q;
-  mspc     = sp->m*c;
+  //mspc     = sp->m*c;                   // rel push
+  //qdt_2mc  = (qsp*sp->g->dt)/(2*mspc);
+  //qdt_4mc2 = qdt_2mc / (2*c);
+  msp      = sp->m;                       // non-rel push
 #ifdef VARIABLE_CHARGE
-  dt_2mc  = (sp->g->dt)/(2*mspc); // Multiply by particle q later
-  dt_4mc2 = dt_2mc / (2*c);
+  dt_2mc   = (sp->g->dt)/(2*msp*c); // Multiply by particle q later
+  dt_4mc   = dt_2mc / 2;
   Kokkos::View<int*, Kokkos::DefaultExecutionSpace> particle_count("particle_count", nv);
 
   // Set initial values to min_q
@@ -313,8 +345,8 @@ accumulate_hydro_p_kokkos(
     });
 
 #else
-  qdt_2mc  = (qsp*sp->g->dt)/(2*mspc);
-  qdt_4mc2 = qdt_2mc / (2*c);
+  qdt_2mc  = (qsp*sp->g->dt)/(2*msp*c);
+  qdt_4mc  = qdt_2mc / 2;
 #endif
   r8V      = sp->g->r8V;
 
@@ -342,7 +374,7 @@ accumulate_hydro_p_kokkos(
 #ifdef VARIABLE_CHARGE
     float qp = k_particles(p_index, particle_var::qp);
     float qdt_2mc = qp*dt_2mc;
-    float qdt_4mc2 = qp*qdt_4mc2;
+    float qdt_4mc = qp*dt_4mc;
 #endif
     int ii = k_particles_i(p_index);
 
@@ -383,11 +415,12 @@ accumulate_hydro_p_kokkos(
     // Boris rotation - curl scalars (0.5 in v0 for half rotate) and
     // kinetic energy computation. Note: gamma-1 = |u|^2 / (gamma+1)
     // is the numerically accurate way to compute gamma-1
-    float ke_mc = ux*ux + uy*uy + uz*uz; // ke_mc = |u|^2 (invariant)
-    float vz = 1; //sqrt(1.0+ke_mc);            // vz = gamma    (invariant)
-    ke_mc *= c/(vz+1.0);             // ke_mc = c|u|^2/(gamma+1) = c*(gamma-1)
-    vz = c/vz;                     // vz = c/gamma
-    float w0 = qdt_4mc2*vz;
+    //float ke_mc = ux*ux + uy*uy + uz*uz; // ke_mc = |u|^2 (invariant)
+    //float vz = 1; //sqrt(1.0+ke_mc);            // vz = gamma    (invariant)
+    //ke_mc *= c/(vz+1.0);             // ke_mc = c|u|^2/(gamma+1) = c*(gamma-1)
+    //vz = c/vz;                     // vz = c/gamma
+    //float w0 = qdt_4mc2*vz;
+    float w0 = qdt_4mc;  // non-rel push
     float w1 = w5*w5 + w6*w6 + w7*w7;    // |cB|^2
     float w2 = w0*w0*w1;
     float w3 = w0*(1.+(1./3.)*w2*(1.0+0.4*w2));
@@ -403,10 +436,13 @@ accumulate_hydro_p_kokkos(
     uy += w4*( w2*w5 - w0*w7 );
     uz += w4*( w0*w6 - w1*w5 );
 
-    // Compute physical velocities
-    float vx  = ux*vz;
-    float vy  = uy*vz;
-    vz *= uz;
+    // Compute physical three-velocities
+    //float vx  = ux*vz;  // rel push
+    //float vy  = uy*vz;
+    //vz *= uz;
+    ux *= c;              // non-rel push
+    uy *= c;
+    uz *= c;
 
     // Compute the trilinear coefficients
     w0  = r8V*w;    // w0 = (1/8)(w/V)
@@ -448,27 +484,49 @@ accumulate_hydro_p_kokkos(
     float q = qsp;
 #endif
     
-    // Accumulate the hydro fields
+    // Accumulate the hydro fields - relativistic version
+//    #define ACCUM_HYDRO( wn, i )                        \
+//    t  = q*wn;        /* t  = (q w/V) trilin_n */		     \
+//    k_hydro_access(i, hydro_var::jx)  += t*vx;                       \
+//    k_hydro_access(i, hydro_var::jy)  += t*vy;                       \
+//    k_hydro_access(i, hydro_var::jz)  += t*vz;                       \
+//    k_hydro_access(i, hydro_var::rho) += t;                          \
+//    t  = mspc*wn;       /* t = (msp c w/V) trilin_n */  \
+//    dx = t*ux;          /* dx = (px w/V) trilin_n */    \
+//    dy = t*uy;                                          \
+//    dz = t*uz;                                          \
+//    k_hydro_access(i, hydro_var::px)  += dx;                         \
+//    k_hydro_access(i, hydro_var::py)  += dy;                         \
+//    k_hydro_access(i, hydro_var::pz)  += dz;                         \
+//    k_hydro_access(i, hydro_var::rho_m) += t; /* changed to mass density (previously ke_mc). Nb. for non-relativistic ke can be computed through trace of pressure tensor below;)*/		     \
+//    k_hydro_access(i, hydro_var::txx) += dx*vx;                      \
+//    k_hydro_access(i, hydro_var::tyy) += dy*vy;                      \
+//    k_hydro_access(i, hydro_var::tzz) += dz*vz;                      \
+//    k_hydro_access(i, hydro_var::tyz) += dy*vz;                      \
+//    k_hydro_access(i, hydro_var::tzx) += dz*vx;                      \
+//    k_hydro_access(i, hydro_var::txy) += dx*vy;
+
+    // Accumulate the hydro fields - non-relativistic version
     #define ACCUM_HYDRO( wn, i )                        \
-    t  = q*wn;        /* t  = (q w/V) trilin_n */		     \
-    k_hydro_access(i, hydro_var::jx)  += t*vx;                       \
-    k_hydro_access(i, hydro_var::jy)  += t*vy;                       \
-    k_hydro_access(i, hydro_var::jz)  += t*vz;                       \
-    k_hydro_access(i, hydro_var::rho) += t;                          \
-    t  = mspc*wn;       /* t = (msp c w/V) trilin_n */  \
+    t  = q*wn;        /* t  = (q w/V) trilin_n */       \
+    k_hydro_access(i, hydro_var::jx)  += t*ux;          \
+    k_hydro_access(i, hydro_var::jy)  += t*uy;          \
+    k_hydro_access(i, hydro_var::jz)  += t*uz;          \
+    k_hydro_access(i, hydro_var::rho) += t;             \
+    t  = msp*wn;        /* t = (msp w/V) trilin_n */    \
     dx = t*ux;          /* dx = (px w/V) trilin_n */    \
     dy = t*uy;                                          \
     dz = t*uz;                                          \
-    k_hydro_access(i, hydro_var::px)  += dx;                         \
-    k_hydro_access(i, hydro_var::py)  += dy;                         \
-    k_hydro_access(i, hydro_var::pz)  += dz;                         \
+    k_hydro_access(i, hydro_var::px)  += dx;            \
+    k_hydro_access(i, hydro_var::py)  += dy;            \
+    k_hydro_access(i, hydro_var::pz)  += dz;            \
     k_hydro_access(i, hydro_var::rho_m) += t; /* changed to mass density (previously ke_mc). Nb. for non-relativistic ke can be computed through trace of pressure tensor below;)*/		     \
-    k_hydro_access(i, hydro_var::txx) += dx*vx;                      \
-    k_hydro_access(i, hydro_var::tyy) += dy*vy;                      \
-    k_hydro_access(i, hydro_var::tzz) += dz*vz;                      \
-    k_hydro_access(i, hydro_var::tyz) += dy*vz;                      \
-    k_hydro_access(i, hydro_var::tzx) += dz*vx;                      \
-    k_hydro_access(i, hydro_var::txy) += dx*vy;
+    k_hydro_access(i, hydro_var::txx) += dx*ux;         \
+    k_hydro_access(i, hydro_var::tyy) += dy*uy;         \
+    k_hydro_access(i, hydro_var::tzz) += dz*uz;         \
+    k_hydro_access(i, hydro_var::tyz) += dy*uz;         \
+    k_hydro_access(i, hydro_var::tzx) += dz*ux;         \
+    k_hydro_access(i, hydro_var::txy) += dx*uy;
 
     // TODO: this serial adding to try and save adds is a bit sad
     // TODO: This is somehow going out of bounds right now

--- a/src/species_advance/standard/hydro_p.cc
+++ b/src/species_advance/standard/hydro_p.cc
@@ -29,7 +29,7 @@ accumulate_hydro_p( hydro_array_t              * RESTRICT ha,
   /**/  hydro_t        * RESTRICT ALIGNED(128) h;
   const particle_t     * RESTRICT ALIGNED(128) p;
   const interpolator_t * RESTRICT ALIGNED(128) f;
-  float c, qsp, msp, qdt_2mc, qdt_4mc, r8V;
+  float c, qsp, msp, qdt_2mc, qdt_4mc, rV;
   int np, stride_10, stride_21, stride_43;
 
   float dx, dy, dz, ux, uy, uz, w;
@@ -51,7 +51,7 @@ accumulate_hydro_p( hydro_array_t              * RESTRICT ha,
   msp      = sp->m;                       // non-rel push
   qdt_2mc  = (qsp*sp->g->dt)/(2*msp*c);
   qdt_4mc  = qdt_2mc / 2;
-  r8V      = sp->g->r8V;
+  rV        = 1.0/(sp->g->dx*sp->g->dy*sp->g->dz);
 
   np        = sp->np;
   stride_10 = VOXEL(1,0,0, sp->g->nx,sp->g->ny,sp->g->nz) -
@@ -116,26 +116,29 @@ accumulate_hydro_p( hydro_array_t              * RESTRICT ha,
     uz *= c;
 
     // Compute the trilinear coefficients
-    w0  = r8V*w;    // w0 = (1/8)(w/V)
-    dx *= w0;       // dx = (1/8)(w/V) x
-    w1  = w0+dx;    // w1 = (1/8)(w/V) + (1/8)(w/V)x = (1/8)(w/V)(1+x)
-    w0 -= dx;       // w0 = (1/8)(w/V) - (1/8)(w/V)x = (1/8)(w/V)(1-x)
-    w3  = 1+dy;     // w3 = 1+y
-    w2  = w0*w3;    // w2 = (1/8)(w/V)(1-x)(1+y)
-    w3 *= w1;       // w3 = (1/8)(w/V)(1+x)(1+y)
-    dy  = 1-dy;     // dy = 1-y
-    w0 *= dy;       // w0 = (1/8)(w/V)(1-x)(1-y)
-    w1 *= dy;       // w1 = (1/8)(w/V)(1+x)(1-y)
-    w7  = 1+dz;     // w7 = 1+z
-    w4  = w0*w7;    // w4 = (1/8)(w/V)(1-x)(1-y)(1+z) = (w/V) trilin_0 *Done
-    w5  = w1*w7;    // w5 = (1/8)(w/V)(1+x)(1-y)(1+z) = (w/V) trilin_1 *Done
-    w6  = w2*w7;    // w6 = (1/8)(w/V)(1-x)(1+y)(1+z) = (w/V) trilin_2 *Done
-    w7 *= w3;       // w7 = (1/8)(w/V)(1+x)(1+y)(1+z) = (w/V) trilin_3 *Done
-    dz  = 1-dz;     // dz = 1-z
-    w0 *= dz;       // w0 = (1/8)(w/V)(1-x)(1-y)(1-z) = (w/V) trilin_4 *Done
-    w1 *= dz;       // w1 = (1/8)(w/V)(1+x)(1-y)(1-z) = (w/V) trilin_5 *Done
-    w2 *= dz;       // w2 = (1/8)(w/V)(1-x)(1+y)(1-z) = (w/V) trilin_6 *Done
-    w3 *= dz;       // w3 = (1/8)(w/V)(1+x)(1+y)(1-z) = (w/V) trilin_7 *Done
+    //w0  = r8V*w;    // w0 = (1/8)(w/V)
+    //dx *= w0;       // dx = (1/8)(w/V) x
+    //w1  = w0+dx;    // w1 = (1/8)(w/V) + (1/8)(w/V)x = (1/8)(w/V)(1+x)
+    //w0 -= dx;       // w0 = (1/8)(w/V) - (1/8)(w/V)x = (1/8)(w/V)(1-x)
+    //w3  = 1+dy;     // w3 = 1+y
+    //w2  = w0*w3;    // w2 = (1/8)(w/V)(1-x)(1+y)
+    //w3 *= w1;       // w3 = (1/8)(w/V)(1+x)(1+y)
+    //dy  = 1-dy;     // dy = 1-y
+    //w0 *= dy;       // w0 = (1/8)(w/V)(1-x)(1-y)
+    //w1 *= dy;       // w1 = (1/8)(w/V)(1+x)(1-y)
+    //w7  = 1+dz;     // w7 = 1+z
+    //w4  = w0*w7;    // w4 = (1/8)(w/V)(1-x)(1-y)(1+z) = (w/V) trilin_0 *Done
+    //w5  = w1*w7;    // w5 = (1/8)(w/V)(1+x)(1-y)(1+z) = (w/V) trilin_1 *Done
+    //w6  = w2*w7;    // w6 = (1/8)(w/V)(1-x)(1+y)(1+z) = (w/V) trilin_2 *Done
+    //w7 *= w3;       // w7 = (1/8)(w/V)(1+x)(1+y)(1+z) = (w/V) trilin_3 *Done
+    //dz  = 1-dz;     // dz = 1-z
+    //w0 *= dz;       // w0 = (1/8)(w/V)(1-x)(1-y)(1-z) = (w/V) trilin_4 *Done
+    //w1 *= dz;       // w1 = (1/8)(w/V)(1+x)(1-y)(1-z) = (w/V) trilin_5 *Done
+    //w2 *= dz;       // w2 = (1/8)(w/V)(1-x)(1+y)(1-z) = (w/V) trilin_6 *Done
+    //w3 *= dz;       // w3 = (1/8)(w/V)(1+x)(1+y)(1-z) = (w/V) trilin_7 *Done
+
+    // Hybrid-VPIC NGP shape
+    w0 = w*rV;
 
     // Accumulate the hydro fields - relativistic version
 //#   define ACCUM_HYDRO( wn)                             \
@@ -182,13 +185,13 @@ accumulate_hydro_p( hydro_array_t              * RESTRICT ha,
     h[i].txy += dx*uy
 
     /**/            ACCUM_HYDRO(w0); // Cell i,j,k
-    i += stride_10; ACCUM_HYDRO(w1); // Cell i+1,j,k
-    i += stride_21; ACCUM_HYDRO(w2); // Cell i,j+1,k
-    i += stride_10; ACCUM_HYDRO(w3); // Cell i+1,j+1,k
-    i += stride_43; ACCUM_HYDRO(w4); // Cell i,j,k+1
-    i += stride_10; ACCUM_HYDRO(w5); // Cell i+1,j,k+1
-    i += stride_21; ACCUM_HYDRO(w6); // Cell i,j+1,k+1
-    i += stride_10; ACCUM_HYDRO(w7); // Cell i+1,j+1,k+1
+//  i += stride_10; ACCUM_HYDRO(w1); // Cell i+1,j,k
+//  i += stride_21; ACCUM_HYDRO(w2); // Cell i,j+1,k
+//  i += stride_10; ACCUM_HYDRO(w3); // Cell i+1,j+1,k
+//  i += stride_43; ACCUM_HYDRO(w4); // Cell i,j,k+1
+//  i += stride_10; ACCUM_HYDRO(w5); // Cell i+1,j,k+1
+//  i += stride_21; ACCUM_HYDRO(w6); // Cell i,j+1,k+1
+//  i += stride_10; ACCUM_HYDRO(w7); // Cell i+1,j+1,k+1
 
 #   undef ACCUM_HYDRO
   }
@@ -310,9 +313,9 @@ accumulate_hydro_p_kokkos(
   k_hydro_sv_t k_hydro_sv = Kokkos::Experimental::create_scatter_view(k_hydro);
 
 #ifdef VARIABLE_CHARGE
-  float c, qsp, msp, dt_2mc, dt_4mc, r8V;
+  float c, qsp, msp, dt_2mc, dt_4mc, rV;
 #else
-  float c, qsp, msp, qdt_2mc, qdt_4mc, r8V;
+  float c, qsp, msp, qdt_2mc, qdt_4mc, rV;
 #endif
   //int np, stride_10, stride_21, stride_43;
 
@@ -348,7 +351,7 @@ accumulate_hydro_p_kokkos(
   qdt_2mc  = (qsp*sp->g->dt)/(2*msp*c);
   qdt_4mc  = qdt_2mc / 2;
 #endif
-  r8V      = sp->g->r8V;
+  rV        = 1.0/(sp->g->dx*sp->g->dy*sp->g->dz);
 
   const int np        = sp->np;
   const int stride_10 = VOXEL(1,0,0, sp->g->nx,sp->g->ny,sp->g->nz) -
@@ -445,26 +448,29 @@ accumulate_hydro_p_kokkos(
     uz *= c;
 
     // Compute the trilinear coefficients
-    w0  = r8V*w;    // w0 = (1/8)(w/V)
-    dx *= w0;       // dx = (1/8)(w/V) x
-    w1  = w0+dx;    // w1 = (1/8)(w/V) + (1/8)(w/V)x = (1/8)(w/V)(1+x)
-    w0 -= dx;       // w0 = (1/8)(w/V) - (1/8)(w/V)x = (1/8)(w/V)(1-x)
-    w3  = 1.0+dy;     // w3 = 1+y
-    w2  = w0*w3;    // w2 = (1/8)(w/V)(1-x)(1+y)
-    w3 *= w1;       // w3 = (1/8)(w/V)(1+x)(1+y)
-    dy  = 1.0-dy;     // dy = 1-y
-    w0 *= dy;       // w0 = (1/8)(w/V)(1-x)(1-y)
-    w1 *= dy;       // w1 = (1/8)(w/V)(1+x)(1-y)
-    w7  = 1.0+dz;     // w7 = 1+z
-    w4  = w0*w7;    // w4 = (1/8)(w/V)(1-x)(1-y)(1+z) = (w/V) trilin_0 *Done
-    w5  = w1*w7;    // w5 = (1/8)(w/V)(1+x)(1-y)(1+z) = (w/V) trilin_1 *Done
-    w6  = w2*w7;    // w6 = (1/8)(w/V)(1-x)(1+y)(1+z) = (w/V) trilin_2 *Done
-    w7 *= w3;       // w7 = (1/8)(w/V)(1+x)(1+y)(1+z) = (w/V) trilin_3 *Done
-    dz  = 1.0-dz;     // dz = 1-z
-    w0 *= dz;       // w0 = (1/8)(w/V)(1-x)(1-y)(1-z) = (w/V) trilin_4 *Done
-    w1 *= dz;       // w1 = (1/8)(w/V)(1+x)(1-y)(1-z) = (w/V) trilin_5 *Done
-    w2 *= dz;       // w2 = (1/8)(w/V)(1-x)(1+y)(1-z) = (w/V) trilin_6 *Done
-    w3 *= dz;       // w3 = (1/8)(w/V)(1+x)(1+y)(1-z) = (w/V) trilin_7 *Done
+    //w0  = r8V*w;    // w0 = (1/8)(w/V)
+    //dx *= w0;       // dx = (1/8)(w/V) x
+    //w1  = w0+dx;    // w1 = (1/8)(w/V) + (1/8)(w/V)x = (1/8)(w/V)(1+x)
+    //w0 -= dx;       // w0 = (1/8)(w/V) - (1/8)(w/V)x = (1/8)(w/V)(1-x)
+    //w3  = 1.0+dy;     // w3 = 1+y
+    //w2  = w0*w3;    // w2 = (1/8)(w/V)(1-x)(1+y)
+    //w3 *= w1;       // w3 = (1/8)(w/V)(1+x)(1+y)
+    //dy  = 1.0-dy;     // dy = 1-y
+    //w0 *= dy;       // w0 = (1/8)(w/V)(1-x)(1-y)
+    //w1 *= dy;       // w1 = (1/8)(w/V)(1+x)(1-y)
+    //w7  = 1.0+dz;     // w7 = 1+z
+    //w4  = w0*w7;    // w4 = (1/8)(w/V)(1-x)(1-y)(1+z) = (w/V) trilin_0 *Done
+    //w5  = w1*w7;    // w5 = (1/8)(w/V)(1+x)(1-y)(1+z) = (w/V) trilin_1 *Done
+    //w6  = w2*w7;    // w6 = (1/8)(w/V)(1-x)(1+y)(1+z) = (w/V) trilin_2 *Done
+    //w7 *= w3;       // w7 = (1/8)(w/V)(1+x)(1+y)(1+z) = (w/V) trilin_3 *Done
+    //dz  = 1.0-dz;     // dz = 1-z
+    //w0 *= dz;       // w0 = (1/8)(w/V)(1-x)(1-y)(1-z) = (w/V) trilin_4 *Done
+    //w1 *= dz;       // w1 = (1/8)(w/V)(1+x)(1-y)(1-z) = (w/V) trilin_5 *Done
+    //w2 *= dz;       // w2 = (1/8)(w/V)(1-x)(1+y)(1-z) = (w/V) trilin_6 *Done
+    //w3 *= dz;       // w3 = (1/8)(w/V)(1+x)(1+y)(1-z) = (w/V) trilin_7 *Done
+
+    // Hybrid-VPIC NGP shape
+    w0 = w*rV;
 
     // TODO: This could easily be a loop?
 
@@ -533,26 +539,26 @@ accumulate_hydro_p_kokkos(
     const int i0 = ii;
     ACCUM_HYDRO(w0, i0); // Cell i,j,k
 
-    const int i1 = i0 + stride_10;
-    ACCUM_HYDRO(w1, i1); // Cell i+1,j,k
-
-    const int i2 = i1 + stride_21;
-    ACCUM_HYDRO(w2, i2); // Cell i,j+1,k
-
-    const int i3 = i2 + stride_10;
-    ACCUM_HYDRO(w3, i3); // Cell i+1,j+1,k
-
-    const int i4 = i3 + stride_43;
-    ACCUM_HYDRO(w4, i4); // Cell i,j,k+1
-
-    const int i5 = i4 + stride_10;
-    ACCUM_HYDRO(w5, i5); // Cell i+1,j,k+1
-
-    const int i6 = i5 + stride_21;
-    ACCUM_HYDRO(w6, i6); // Cell i,j+1,k+1
-
-    const int i7 = i6 + stride_10;
-    ACCUM_HYDRO(w7, i7); // Cell i+1,j+1,k+1
+//    const int i1 = i0 + stride_10;
+//    ACCUM_HYDRO(w1, i1); // Cell i+1,j,k
+//
+//    const int i2 = i1 + stride_21;
+//    ACCUM_HYDRO(w2, i2); // Cell i,j+1,k
+//
+//    const int i3 = i2 + stride_10;
+//    ACCUM_HYDRO(w3, i3); // Cell i+1,j+1,k
+//
+//    const int i4 = i3 + stride_43;
+//    ACCUM_HYDRO(w4, i4); // Cell i,j,k+1
+//
+//    const int i5 = i4 + stride_10;
+//    ACCUM_HYDRO(w5, i5); // Cell i+1,j,k+1
+//
+//    const int i6 = i5 + stride_21;
+//    ACCUM_HYDRO(w6, i6); // Cell i,j+1,k+1
+//
+//    const int i7 = i6 + stride_10;
+//    ACCUM_HYDRO(w7, i7); // Cell i+1,j+1,k+1
 
 #   undef ACCUM_HYDRO
   });

--- a/src/util/io/FileIO.h
+++ b/src/util/io/FileIO.h
@@ -14,6 +14,7 @@
 
 #include <stdarg.h>
 #include "FileIOData.h"
+#include <cstdint>
 
 /*!
 	\class FileIO FileIO.h

--- a/src/util/io/StandardIOPolicy.h
+++ b/src/util/io/StandardIOPolicy.h
@@ -15,6 +15,7 @@
 #include <string>
 #include <cstdarg>
 #include <cstdio>
+#include <cstdint>
 
 #include "FileIOData.h"
 


### PR DESCRIPTION
Fixes issue https://github.com/lanl/vpic-kokkos/issues/103 ; supersedes old PR https://github.com/lanl/vpic-kokkos/pull/105

Probably easiest to review each commit separately.

* NGP shape fix is straightforward, I hope.

* Devel branch already fixed relativistic gammas by setting `vz=1`.  Commit 1dbc893 removes unneeded intermediate variables and relocates factors of `cvac` to be a bit more logical / readable.  The code's structure for half-timestep particle push thus becomes closer to, e.g., `center_p_pipeline` and `uncenter_p_kokkos`, which both use `qdt_4mc` instead of `qdt_4mc2`.