### PR TITLE
[hvpic-k-devel] EM field scalar energies, two bugfixes: correct stencils, include bkg B field

### DIFF
--- a/src/field_advance/standard/energy_f.cc
+++ b/src/field_advance/standard/energy_f.cc
@@ -135,9 +135,25 @@ struct field_reduce {
         en[0] += k_field(f0,  field_var::ex) * k_field(f0,  field_var::ex);
         en[1] += k_field(f0,  field_var::ey) * k_field(f0,  field_var::ey);
         en[2] += k_field(f0,  field_var::ez) * k_field(f0,  field_var::ez);
-        en[3] += k_field(f0,  field_var::cbx) * k_field(f0,  field_var::cbx);
-        en[4] += k_field(f0,  field_var::cby) * k_field(f0,  field_var::cby);
-        en[5] += k_field(f0,  field_var::cbz) * k_field(f0,  field_var::cbz);
+        en[3] += (  (k_field(f0,field_var::cbx0) + k_field(f0,field_var::cbx))
+                   *(k_field(f0,field_var::cbx0) + k_field(f0,field_var::cbx)) );
+        en[4] += (  (k_field(f0,field_var::cby0) + k_field(f0,field_var::cby))
+                   *(k_field(f0,field_var::cby0) + k_field(f0,field_var::cby)) );
+        en[5] += (  (k_field(f0,field_var::cbz0) + k_field(f0,field_var::cbz))
+                   *(k_field(f0,field_var::cbz0) + k_field(f0,field_var::cbz)) );
+        // If background B0 >> dB, and floating-point error accumulated during
+        // reduction becomes large, we may lose precision in the measurement of
+        // fluctuating magnetic energy.  It may be necessary to separate
+        // (B0 + dB)^2 = B0^2 + 2*B0*dB + dB^2.
+        //en[3] += k_field(f0,  field_var::cbx) * k_field(f0,  field_var::cbx);
+        //en[4] += k_field(f0,  field_var::cby) * k_field(f0,  field_var::cby);
+        //en[5] += k_field(f0,  field_var::cbz) * k_field(f0,  field_var::cbz);
+        //en[6] += 2 * k_field(f0, field_var::cbx0) * k_field(f0, field_var::cbx);
+        //en[7] += 2 * k_field(f0, field_var::cby0) * k_field(f0, field_var::cby);
+        //en[8] += 2 * k_field(f0, field_var::cbz0) * k_field(f0, field_var::cbz);
+        //en[9]  += k_field(f0, field_var::cbx0) * k_field(f0, field_var::cbx0);
+        //en[10] += k_field(f0, field_var::cby0) * k_field(f0, field_var::cby0);
+        //en[11] += k_field(f0, field_var::cbz0) * k_field(f0, field_var::cbz0);
         }
 
    KOKKOS_INLINE_FUNCTION void

--- a/src/field_advance/standard/sfa.cc
+++ b/src/field_advance/standard/sfa.cc
@@ -258,12 +258,14 @@ new_standard_field_array( grid_t           * RESTRICT g,
   fa->kernel->hyb_smooth_b      = hyb_smooth_b;
   fa->kernel->hyb_smooth_eb_interp = hyb_smooth_eb_interp;
 
+  fa->kernel->energy_f          = energy_f;
+  fa->kernel->energy_f_kokkos   = energy_f_kokkos;
 
   if( !m_list->next ) {
     /* If there is only one material, then this material permeates all
        space and we can use high performance versions of some kernels. */
     //fa->kernel->advance_e         = vacuum_advance_e;
-    fa->kernel->energy_f          = vacuum_energy_f;
+    //fa->kernel->energy_f          = vacuum_energy_f;
     fa->kernel->compute_rhob      = vacuum_compute_rhob;
     fa->kernel->compute_curl_b    = vacuum_compute_curl_b;
     fa->kernel->compute_div_e_err = vacuum_compute_div_e_err;
@@ -271,7 +273,7 @@ new_standard_field_array( grid_t           * RESTRICT g,
     fa->kernel->advance_e_kokkos  = vacuum_advance_e_kokkos;
     fa->kernel->compute_div_e_err_kokkos = vacuum_compute_div_e_err_kokkos;
     fa->kernel->clean_div_e_kokkos= vacuum_clean_div_e_kokkos;
-    fa->kernel->energy_f_kokkos   = vacuum_energy_f_kokkos;
+    //fa->kernel->energy_f_kokkos   = vacuum_energy_f_kokkos;
   }
 
   REGISTER_OBJECT( fa, checkpt_standard_field_array,


### PR DESCRIPTION
Two changes:

* Field energy calculation used "vacuum_" methods w/fully-kinetic VPIC stencils; now fixed to compute on device w/HVPIC cell-centered mesh stencils

* Change from δB^2 –> (B0 + δB)^2 in `energy_f_kokkos`.  Beware of precision loss for simulations with B0 >> δB.  The user interface in this PR isn't great b/c requires source-code tampering, but trying to build a more general deck-accessible toggle seems inelegant & unclear how many people would actually need/want it.