### PR TITLE
[hvpic-k-devel] bitfield uint64_t to dump all field struct attrs

### DIFF
--- a/src/util/bitfield.h
+++ b/src/util/bitfield.h
@@ -5,37 +5,37 @@ class BitField
 	{
 	public:
 		
-		BitField(uint32_t setbits = 0xffffffff) : bits_(setbits) {}
+		BitField(uint64_t setbits = UINT64_MAX) : bits_(setbits) {}
 		BitField(const BitField & bf) : bits_(bf.bits_) {}
 		~BitField() {}
 
 		/*!---------------------------------------------------------------------
 		 * Set bits in mask.
 		----------------------------------------------------------------------*/
-		uint32_t set(uint32_t mask) {
+		uint64_t set(uint64_t mask) {
 			return bits_ |= mask;
 		} // set
 
 		/*!---------------------------------------------------------------------
 		 * Set individual bit.
 		----------------------------------------------------------------------*/
-		uint32_t setibit(size_t bit) {
-			uint32_t tmp = 1<<bit;
+		uint64_t setibit(size_t bit) {
+			uint64_t tmp = 1ULL<<bit;
 			return bits_ |= tmp;
 		} // setibit
 
 		/*!---------------------------------------------------------------------
 		 * Clear bits in mask.
 		----------------------------------------------------------------------*/
-		uint32_t clear(uint32_t mask) {
+		uint64_t clear(uint64_t mask) {
 			return bits_ &= ~mask;
 		} // clear
 
 		/*!---------------------------------------------------------------------
 		 * Clear individual bit.
 		----------------------------------------------------------------------*/
-		uint32_t clearbit(size_t bit) {
-			uint32_t tmp = 1<<bit;
+		uint64_t clearbit(size_t bit) {
+			uint64_t tmp = 1ULL<<bit;
 			return bits_ &= ~tmp;
 		} // clearbit
 
@@ -43,15 +43,15 @@ class BitField
 		 * Check whether bit at index is set.
 		----------------------------------------------------------------------*/
 		bool bitset(size_t bit) const {
-			uint32_t tmp = 1<<bit;
+			uint64_t tmp = 1ULL<<bit;
 			return tmp & bits_;
 		} // bitset
 
 		/*!---------------------------------------------------------------------
 		 * Check whether bits in mask are set.
 		----------------------------------------------------------------------*/
-		bool bitsset(uint32_t mask) const {
-			uint32_t tmp = 1<<mask;
+		bool bitsset(uint64_t mask) const {
+			uint64_t tmp = 1ULL<<mask;
 			return tmp & bits_;
 		} // bitset
 
@@ -59,7 +59,7 @@ class BitField
 		 * Check whether bit at index is clear.
 		----------------------------------------------------------------------*/
 		bool bitclear(size_t bit) const {
-			uint32_t tmp = 1<<bit;
+			uint64_t tmp = 1ULL<<bit;
 			return !(tmp & bits_);
 		} // bitclear
 
@@ -81,7 +81,7 @@ class BitField
 		----------------------------------------------------------------------*/
 		size_t bitsum() const {
 			size_t sum(0);
-			for(size_t i(0); i<32; i++) {
+			for(size_t i(0); i<64; i++) {
 				if(bitset(i)) {
 					++sum;
 				} // if
@@ -91,7 +91,7 @@ class BitField
 
 	private:
 
-		uint32_t bits_;
+		uint64_t bits_;
 
 	}; // class BitField
 

--- a/src/vpic/vpic.h
+++ b/src/vpic/vpic.h
@@ -45,29 +45,30 @@ class HDF5Dump;
 
 /* typedef FileIO FILETYPE; */
 
-const uint32_t allvars		(0xffffffff);
-const uint32_t electric		(1<<0 | 1<<1 | 1<<2);
-const uint32_t div_e_err	(1<<3);
-const uint32_t magnetic		(1<<4 | 1<<5 | 1<<6);
-const uint32_t pe  		(1<<7);
-const uint32_t tca			(1<<8 | 1<<9 | 1<<10);
-const uint32_t rhob			(1<<11);
-const uint32_t current		(1<<12 | 1<<13 | 1<<14);
-const uint32_t rhof			(1<<15);
-const uint32_t currentold	(1<<16 | 1<<17 | 1<<18);
-const uint32_t rhofold		(1<<19);
-const uint32_t magnetic0	(1<<20 | 1<<21 | 1<<22);
-const uint32_t te0		(1<<23);
-const uint32_t tempt		(1<<24 | 1<<25 | 1<<26);
-const uint32_t te			(1<<27);
-const uint32_t tempo		(1<<28 | 1<<29 | 1<<30);
-const uint32_t oe			(1<<31);
-//const uint32_t tempp		(1<<32 | 1<<33 | 1<<34);
-//const uint32_t pe			(1<<35);
-//const uint32_t emat			(1<<36 | 1<<37 | 1<<38);
-//const uint32_t nmat			(1<<39);
-//const uint32_t fmat			(1<<40 | 1<<41 | 1<<42);
-//const uint32_t cmat			(1<<43);
+const uint64_t allvars      UINT64_MAX; //(0xffffffffffffffff);
+const uint64_t electric     (1ULL<<0 | 1ULL<<1 | 1ULL<<2);
+const uint64_t div_e_err    (1ULL<<3);
+const uint64_t magnetic     (1ULL<<4 | 1ULL<<5 | 1ULL<<6);
+const uint64_t pe           (1ULL<<7);
+const uint64_t tca          (1ULL<<8 | 1ULL<<9 | 1ULL<<10);
+const uint64_t rhob         (1ULL<<11);
+const uint64_t current      (1ULL<<12 | 1ULL<<13 | 1ULL<<14);
+const uint64_t rhof         (1ULL<<15);
+const uint64_t currentold   (1ULL<<16 | 1ULL<<17 | 1ULL<<18);
+const uint64_t rhofold      (1ULL<<19);
+const uint64_t magnetic0    (1ULL<<20 | 1ULL<<21 | 1ULL<<22);
+const uint64_t te0          (1ULL<<23);
+const uint64_t tempt        (1ULL<<24 | 1ULL<<25 | 1ULL<<26);
+const uint64_t te           (1ULL<<27);
+const uint64_t tempo        (1ULL<<28 | 1ULL<<29 | 1ULL<<30);
+const uint64_t oe           (1ULL<<31);
+//const uint64_t tempp      (1ULL<<32 | 1ULL<<33 | 1ULL<<34);
+//const uint64_t pe         (1ULL<<35);
+//const uint64_t emat       (1ULL<<36 | 1ULL<<37 | 1ULL<<38);
+//const uint64_t nmat       (1ULL<<39);
+//const uint64_t fmat       (1ULL<<40 | 1ULL<<41 | 1ULL<<42);
+//const uint64_t cmat       (1ULL<<43);
+// 1ULL = unsigned long long ensures 64bits for bitshift operators
 
 const size_t total_field_variables(32);
 const size_t total_field_groups(16); // this counts vectors, tensors etc...
@@ -82,17 +83,17 @@ struct FieldInfo {
 	size_t size;
 }; // struct FieldInfo
 
-const uint32_t current_density	(1<<0 | 1<<1 | 1<<2);
-const uint32_t charge_density	(1<<3);
-const uint32_t momentum_density	(1<<4 | 1<<5 | 1<<6);
-const uint32_t mass_density		(1<<7);
-const uint32_t stress_tensor	(1<<8 | 1<<9 | 1<<10 | 1<<11 | 1<<12 | 1<<13);
+const uint64_t current_density  (1ULL<<0 | 1ULL<<1 | 1ULL<<2);
+const uint64_t charge_density   (1ULL<<3);
+const uint64_t momentum_density (1ULL<<4 | 1ULL<<5 | 1ULL<<6);
+const uint64_t mass_density     (1ULL<<7);
+const uint64_t stress_tensor    (1ULL<<8 | 1ULL<<9 | 1ULL<<10 | 1ULL<<11 | 1ULL<<12 | 1ULL<<13);
 #ifdef VARIABLE_CHARGE
-const uint32_t charge_diags     (1<<14 | 1<<15);
+const uint64_t charge_diags     (1ULL<<14 | 1ULL<<15);
 #endif
 /* May want to use these instead
-const uint32_t stress_diagonal 		(1<<8 | 1<<9 | 1<<10);
-const uint32_t stress_offdiagonal	(1<<11 | 1<<12 | 1<<13);
+const uint64_t stress_diagonal      (1ULL<<8 | 1ULL<<9 | 1ULL<<10);
+const uint64_t stress_offdiagonal   (1ULL<<11 | 1ULL<<12 | 1ULL<<13);
 */
 
 #ifdef VARIABLE_CHARGE
@@ -141,7 +142,7 @@ enum DumpFormat {
 ----------------------------------------------------------------------------*/
 struct DumpParameters {
 
-  void output_variables(uint32_t mask) {
+  void output_variables(uint64_t mask) {
     output_vars.set(mask);
   } // output_variables
 
@@ -152,7 +153,7 @@ struct DumpParameters {
 
     format = band;
 
-    output_vars.set((0xffffffff));
+    output_vars.set(UINT64_MAX);  // same as 0xffffffffffffffff
 
     //    strcpy(baseDir, dumptype);
     //    strcpy(baseFileName, dumptype);


### PR DESCRIPTION
previously could not dump fields at >32nd attribute slot

NOTE: this commit does not add bitmask aliases for "trailing" fields in struct: pex, pey, pez, div_b_err, ux, uy, uz, ue, sx, sy, sz, se, emat{x,y,z}, nmat, fmat{x,y,z}, cmat because that would require more testing to guard against namespace collisions etc... so a user should invoke `allvars`, manually hard-code bitmasks, or make necessary source code edit on their own, for now