### PR TITLE
[hvpic-k-devel] Quadratic-sum particle shape

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,8 @@ option(VPIC_ENABLE_GPU_AWARE_MPI "Enable GPU-aware MPI. Allows GPUs to communica
 
 option(VPIC_ENABLE_HALO_EXCHANGE "Enable halo exchange code path for remote communication. Temporary option until halo exchange code is accurately tested." ON)
 
+option(VPIC_SHAPE_QS "Use quadratic-sum particle shape" OFF)
+
 option(HYB_USE_SEPARATE_PE "Use separate electron energy equation instead of EoS." OFF)
 
 option(HYB_USE_STATIC_E "Use electrostatic hybrid field solver." OFF)
@@ -380,6 +382,16 @@ if (VPIC_ENABLE_HALO_EXCHANGE)
   add_definitions(-DVPIC_ENABLE_HALO_EXCHANGE)
   message("--     VPIC: Enabled Halo exchange path")
 endif(VPIC_ENABLE_HALO_EXCHANGE)
+
+if (VPIC_SHAPE_QS)
+  add_definitions(-DSHAPE_QS)
+  message("--     VPIC: Using quadratic-sum particle shape")
+  set(VPIC_CXX_FLAGS "${VPIC_CXX_FLAGS} -DSHAPE_QS")
+else()
+  add_definitions(-DSHAPE_NGP)
+  message("--     VPIC: Using nearest-grid-point particle shape")
+  set(VPIC_CXX_FLAGS "${VPIC_CXX_FLAGS} -DSHAPE_NGP")
+endif(VPIC_SHAPE_QS)
 
 if (HYB_USE_SEPARATE_PE)
    add_definitions(-DHYB_USE_SEPARATE_PE)

--- a/src/field_advance/standard/hyb_advance_b.cc
+++ b/src/field_advance/standard/hyb_advance_b.cc
@@ -85,12 +85,25 @@ hyb_advance_b(field_array_t * RESTRICT fa,
   Kokkos::Profiling::pushRegion("HybyridAdvanceB::Smooth_Ion_Moments");
   //Only smooth on the first subcycle
   if (isub==0) {
+#ifndef SHAPE_NGP
+    //fix edge rho/currents for local BCs
+    //adds adjacent ghost rho/current to cell and sets BC ghosts to 0
+    k_hyb_local_adjust_jf(fa, fa->g);
+    //fix edge rho/currents everywhere else
+    //sends ghosts across ranks and adds ghosts to adjacent cells
+    k_begin_remote_edge_hyb_jf(fa, fa->g, *(fa->fb) );
+    k_end_remote_edge_hyb_jf  (fa, fa->g, *(fa->fb) );
+#else
+    // NGP accumulates only on live cells; ghosts empty.
+    // So no need to fix edge rho/currents
+#endif
     
-    //smooth moments
+    //refresh all ghosts
     Kokkos::Profiling::pushRegion("HybyridAdvanceB::Smooth_Ion_Moments::Exchange_JF");
     k_begin_remote_ghost_hyb_jf(fa, fa->g, *(fa->fb) );
     k_end_remote_ghost_hyb_jf  (fa, fa->g, *(fa->fb) );
     Kokkos::Profiling::popRegion();
+    //fix ghosts for local BCs
     Kokkos::Profiling::pushRegion("HybyridAdvanceB::Smooth_Ion_Moments::Apply_Local_Ghost_JF");
     k_hyb_local_ghost_jf  (fa, fa->g);
     Kokkos::Profiling::popRegion();

--- a/src/field_advance/standard/local.cc
+++ b/src/field_advance/standard/local.cc
@@ -2116,47 +2116,48 @@ k_hyb_local_ghost_lapl_b( field_array_t      * RESTRICT f,
 
 //Hybrid adjust jf,rhof
 
-template<typename T> void adjust_hyb_local_jf(int i, int j, int k,
-                                              const int nx, const int ny, const int nz,
-                                              field_array_t* RESTRICT f, const grid_t* g) {}
-
-#define ADJUSTLOCAL(x_,y_,z_)                                                       \
-  int bc = g->bc[BOUNDARY(i,j,k)];                                                  \
-  k_field_t k_field = f->k_f_d;                                                     \
-  Kokkos::MDRangePolicy<Kokkos::Rank<2> > x_##_face({1,1},{n##y_+1,n##z_+1});       \
-  if(bc < 0 || bc >= world_size) {                                                  \
-    int x_ = (i+j+k)<0 ? 1 : n##x_;  /* adjust edges */                             \
-    switch(bc) {                                                                    \
-    case anti_symmetric_fields:                                                     \
-    case symmetric_fields:                                                          \
-      Kokkos::parallel_for("adjust_hyb_local_jf: anti_symmetric_fields",            \
-                           x_##_face, KOKKOS_LAMBDA(const int y_, const int z_) {   \
-          /*  add ghost cell to adjacent local BC cell, then set ghost to 0 */      \
-          k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfx)  += k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::jfx);  \
-          k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfy)  += k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::jfy);  \
-          k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfz)  += k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::jfz);  \
-          k_field(VOXEL(x,y,z,nx,ny,nz), field_var::rhof) += k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::rhof); \
-          k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::jfx)  = 0;    \
-          k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::jfy)  = 0;    \
-          k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::jfz)  = 0;    \
-          k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::rhof) = 0;    \
-        });                                                             \
-      break;                                                            \
-    default:                                                            \
-      ERROR(("Bad boundary condition encountered."));                   \
-      break;                                                            \
-    }                                                                   \
+#define ADJUST_LOCAL(x_,y_,z_)                                                 \
+  int bc = g->bc[BOUNDARY(i,j,k)];                                             \
+  k_field_t k_field = f->k_f_d;                                                \
+  Kokkos::MDRangePolicy<Kokkos::Rank<2> > x_##_face({1,1},{n##y_+1,n##z_+1});  \
+  if(bc < 0 || bc >= world_size) {                                             \
+    int x_ = (i+j+k)<0 ? 1 : n##x_;  /* adjust edges */                        \
+    switch(bc) {                                                               \
+    case anti_symmetric_fields:                                                \
+    case symmetric_fields:                                                     \
+      Kokkos::parallel_for("adjust_hyb_local_jf: symmetric_fields", x_##_face, \
+                           KOKKOS_LAMBDA(const int y_, const int z_) {         \
+          /*  add ghost cell to adjacent local BC cell, then set ghost to 0 */ \
+          const int local = VOXEL(x,y,z,nx,ny,nz);                             \
+          const int ghost = VOXEL(x+i,y+j,z+k,nx,ny,nz);                       \
+          k_field(local, field_var::jfx)  += k_field(ghost, field_var::jfx);   \
+          k_field(local, field_var::jfy)  += k_field(ghost, field_var::jfy);   \
+          k_field(local, field_var::jfz)  += k_field(ghost, field_var::jfz);   \
+          k_field(local, field_var::rhof) += k_field(ghost, field_var::rhof);  \
+          k_field(ghost, field_var::jfx)  = 0;                                 \
+          k_field(ghost, field_var::jfy)  = 0;                                 \
+          k_field(ghost, field_var::jfz)  = 0;                                 \
+          k_field(ghost, field_var::rhof) = 0;                                 \
+        });                                                                    \
+      break;                                                                   \
+    default:                                                                   \
+      ERROR(("Bad boundary condition encountered."));                          \
+      break;                                                                   \
+    }                                                                          \
   }
 
-template<> void adjust_hyb_local_jf<XYZ>(int i, int j, int k,
-                                         const int nx, const int ny, const int nz,
-				         field_array_t* RESTRICT f, const grid_t* g) { ADJUSTLOCAL(x,y,z); }
-template<> void adjust_hyb_local_jf<YZX>(int i, int j, int k,
-                                         const int nx, const int ny, const int nz,
-				         field_array_t* RESTRICT f, const grid_t* g) { ADJUSTLOCAL(y,z,x); }
-template<> void adjust_hyb_local_jf<ZXY>(int i, int j, int k,
-                                         const int nx, const int ny, const int nz,
-				         field_array_t* RESTRICT f, const grid_t* g) { ADJUSTLOCAL(z,x,y); }
+template<typename T> 
+void adjust_hyb_local_jf(const int i, const int j, const int k,
+                         const int nx, const int ny, const int nz,
+                         field_array_t* RESTRICT f, const grid_t* g) {
+  if constexpr (std::is_same_v<T,XYZ>) {
+    ADJUST_LOCAL(x,y,z);
+  } else if constexpr (std::is_same_v<T,YZX>) {
+    ADJUST_LOCAL(y,z,x);
+  } else if constexpr (std::is_same_v<T,YZX>) {
+    ADJUST_LOCAL(z,x,y);
+  }
+}
 
 void
 k_hyb_local_adjust_jf( field_array_t * RESTRICT f,

--- a/src/field_advance/standard/local.cc
+++ b/src/field_advance/standard/local.cc
@@ -1755,6 +1755,9 @@ void k_local_adjust_rhob(field_array_t* fa, const grid_t* g) {
     adjust_rhob<ZXY>(fa, g, 0, 0, 1);
 }
 
+/*****************************************************************************
+ * Hybrid local ghosts
+ *****************************************************************************/
 
 //Hybrid local B field
 
@@ -2107,3 +2110,65 @@ k_hyb_local_ghost_lapl_b( field_array_t      * RESTRICT f,
 
 #undef APPLYLOCAL
 
+/*****************************************************************************
+ * Hybrid local adjusts
+ *****************************************************************************/
+
+//Hybrid adjust jf,rhof
+
+template<typename T> void adjust_hyb_local_jf(int i, int j, int k,
+                                              const int nx, const int ny, const int nz,
+                                              field_array_t* RESTRICT f, const grid_t* g) {}
+
+#define ADJUSTLOCAL(x_,y_,z_)                                                       \
+  int bc = g->bc[BOUNDARY(i,j,k)];                                                  \
+  k_field_t k_field = f->k_f_d;                                                     \
+  Kokkos::MDRangePolicy<Kokkos::Rank<2> > x_##_face({1,1},{n##y_+1,n##z_+1});       \
+  if(bc < 0 || bc >= world_size) {                                                  \
+    int x_ = (i+j+k)<0 ? 1 : n##x_;  /* adjust edges */                             \
+    switch(bc) {                                                                    \
+    case anti_symmetric_fields:                                                     \
+    case symmetric_fields:                                                          \
+      Kokkos::parallel_for("adjust_hyb_local_jf: anti_symmetric_fields",            \
+                           x_##_face, KOKKOS_LAMBDA(const int y_, const int z_) {   \
+          /*  add ghost cell to adjacent local BC cell, then set ghost to 0 */      \
+          k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfx)  += k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::jfx);  \
+          k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfy)  += k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::jfy);  \
+          k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfz)  += k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::jfz);  \
+          k_field(VOXEL(x,y,z,nx,ny,nz), field_var::rhof) += k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::rhof); \
+          k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::jfx)  = 0;    \
+          k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::jfy)  = 0;    \
+          k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::jfz)  = 0;    \
+          k_field(VOXEL(x+i,y+j,z+k,nx,ny,nz), field_var::rhof) = 0;    \
+        });                                                             \
+      break;                                                            \
+    default:                                                            \
+      ERROR(("Bad boundary condition encountered."));                   \
+      break;                                                            \
+    }                                                                   \
+  }
+
+template<> void adjust_hyb_local_jf<XYZ>(int i, int j, int k,
+                                         const int nx, const int ny, const int nz,
+				         field_array_t* RESTRICT f, const grid_t* g) { ADJUSTLOCAL(x,y,z); }
+template<> void adjust_hyb_local_jf<YZX>(int i, int j, int k,
+                                         const int nx, const int ny, const int nz,
+				         field_array_t* RESTRICT f, const grid_t* g) { ADJUSTLOCAL(y,z,x); }
+template<> void adjust_hyb_local_jf<ZXY>(int i, int j, int k,
+                                         const int nx, const int ny, const int nz,
+				         field_array_t* RESTRICT f, const grid_t* g) { ADJUSTLOCAL(z,x,y); }
+
+void
+k_hyb_local_adjust_jf( field_array_t * RESTRICT f,
+                        const grid_t *          g ) {
+    const int nx = g->nx, ny = g->ny, nz = g->nz;
+
+    adjust_hyb_local_jf<XYZ>(-1,0,0,nx,ny,nz,f,g);
+    adjust_hyb_local_jf<YZX>(0,-1,0,nx,ny,nz,f,g);
+    adjust_hyb_local_jf<ZXY>(0,0,-1,nx,ny,nz,f,g);
+    adjust_hyb_local_jf<XYZ>(1,0,0, nx,ny,nz,f,g);
+    adjust_hyb_local_jf<YZX>(0,1,0, nx,ny,nz,f,g);
+    adjust_hyb_local_jf<ZXY>(0,0,1, nx,ny,nz,f,g);
+}
+
+#undef ADJUSTLOCAL

--- a/src/field_advance/standard/remote.cc
+++ b/src/field_advance/standard/remote.cc
@@ -3929,20 +3929,31 @@ begin_recv_edge_hyb_jf(field_array* fa, const int i, const int j, const int k) {
 
 #undef BRP
 
-#define BSP(x_,y_,z_)                                                   \
-  const int nx = fa->g->nx, ny = fa->g->ny, nz = fa->g->nz;             \
-  const int size = (4*n##y_*n##z_)*sizeof(float);                       \
-  const int face = (i+j+k)<0 ? 0 : n##x_+1; /* send ghosts to edges */  \
-  const k_field_t& k_field = fa->k_f_d;                                 \
-  Kokkos::MDRangePolicy<Kokkos::Rank<2>> x_##_face({1, 1}, {n##z_+1, n##y_+1}); \
-  Kokkos::parallel_for("begin_send_edge_hyb_jf<XYZ>", x_##_face, KOKKOS_LAMBDA(const int z_, const int y_) { \
-      const int x_ = face;                                              \
-      sbuf_d(                (z_-1)*n##y_ + (y_-1)) = k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfx); \
-      sbuf_d(  n##y_*n##z_ + (z_-1)*n##y_ + (y_-1)) = k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfy); \
-      sbuf_d(2*n##y_*n##z_ + (z_-1)*n##y_ + (y_-1)) = k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfz); \
-      sbuf_d(3*n##y_*n##z_ + (z_-1)*n##y_ + (y_-1)) = k_field(VOXEL(x,y,z,nx,ny,nz), field_var::rhof);\
-    });                                                                 \
-  SYNC_MPI_BUFFER(sbuf_h, sbuf_d);                                      \
+#define BSP(x_,y_,z_)                                                          \
+  const int nx = fa->g->nx, ny = fa->g->ny, nz = fa->g->nz;                    \
+  const int size = (4*n##y_*n##z_)*sizeof(float);                              \
+  const int face = (i+j+k)<0 ? 0 : n##x_+1; /* send ghosts to edges */         \
+  const k_field_t& k_field = fa->k_f_d;                                        \
+  const int face_len = n##y_ * n##z_;                                          \
+  auto jfx_buff  = Kokkos::subview(sbuf_d, Kokkos::make_pair(0*face_len,       \
+                                                             1*face_len));     \
+  auto jfy_buff  = Kokkos::subview(sbuf_d, Kokkos::make_pair(1*face_len,       \
+                                                             2*face_len));     \
+  auto jfz_buff  = Kokkos::subview(sbuf_d, Kokkos::make_pair(2*face_len,       \
+                                                             3*face_len));     \
+  auto rhof_buff = Kokkos::subview(sbuf_d, Kokkos::make_pair(3*face_len,       \
+                                                             4*face_len));     \
+  Kokkos::MDRangePolicy<Kokkos::Rank<2>> x_##_face({1,1}, {n##y_+1, n##z_+1}); \
+  Kokkos::parallel_for("begin_send_edge_hyb_jf<" #x_ #y_ #z_ ">", x_##_face,   \
+    KOKKOS_LAMBDA(const int y_, const int z_) {                                \
+      const int x_ = face;                                                     \
+      const int voxel = VOXEL(x,y,z,nx,ny,nz);                                 \
+      jfx_buff( (z_-1)*n##y_ + (y_-1)) = k_field(voxel, field_var::jfx);       \
+      jfy_buff( (z_-1)*n##y_ + (y_-1)) = k_field(voxel, field_var::jfy);       \
+      jfz_buff( (z_-1)*n##y_ + (y_-1)) = k_field(voxel, field_var::jfz);       \
+      rhof_buff((z_-1)*n##y_ + (y_-1)) = k_field(voxel, field_var::rhof);      \
+    });                                                                        \
+  SYNC_MPI_BUFFER(sbuf_h, sbuf_d);                                             \
   BEGIN_SEND_PORT_K(i,j,k,size,fa->g, sbuf_d, sbuf_h);
 
 /**
@@ -4025,22 +4036,33 @@ void k_begin_remote_edge_hyb_jf(field_array_t* ALIGNED(128) fa,
 //#endif
 }
 
-#define ERP(x_,y_,z_)                                                   \
-  const grid_t* g = fa->g;                                              \
-  float* p = reinterpret_cast<float*>(end_recv_port_k(i,j,k,g));        \
-  if(p) {                                                               \
-    const int nx = g->nx, ny = g->ny, nz = g->nz;                       \
-    const int face = (i+j+k) < 0 ? n##x_ : 1; /*add ghosts to edges*/   \
-    const k_field_t& k_field = fa->k_f_d;                               \
-    SYNC_MPI_BUFFER(rbuf_d, rbuf_h);                                    \
-    Kokkos::MDRangePolicy<Kokkos::Rank<2>> x_##_face({1, 1}, {n##z_+1, n##y_+1}); \
-    Kokkos::parallel_for("end_recv_edge_hyb_jf<XYZ>", x_##_face, KOKKOS_LAMBDA(const int z_, const int y_) { \
-        const int x_ = face;                                            \
-        k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfx)  += rbuf_d(                (z_-1)*n##y_ + (y_-1)); \
-        k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfy)  += rbuf_d(  n##y_*n##z_ + (z_-1)*n##y_ + (y_-1)); \
-        k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfz)  += rbuf_d(2*n##y_*n##z_ + (z_-1)*n##y_ + (y_-1)); \
-        k_field(VOXEL(x,y,z,nx,ny,nz), field_var::rhof) += rbuf_d(3*n##y_*n##z_ + (z_-1)*n##y_ + (y_-1)); \
-      });                                                               \
+#define ERP(x_,y_,z_)                                                          \
+  const grid_t* g = fa->g;                                                     \
+  float* p = reinterpret_cast<float*>(end_recv_port_k(i,j,k,g));               \
+  if(p) {                                                                      \
+    const int nx = g->nx, ny = g->ny, nz = g->nz;                              \
+    const int face = (i+j+k) < 0 ? n##x_ : 1; /*add ghosts to edges*/          \
+    const k_field_t& k_field = fa->k_f_d;                                      \
+    const int face_len = n##y_ * n##z_;                                        \
+    auto jfx_buff  = Kokkos::subview(rbuf_d, Kokkos::make_pair(0*face_len,     \
+                                                               1*face_len));   \
+    auto jfy_buff  = Kokkos::subview(rbuf_d, Kokkos::make_pair(1*face_len,     \
+                                                               2*face_len));   \
+    auto jfz_buff  = Kokkos::subview(rbuf_d, Kokkos::make_pair(2*face_len,     \
+                                                               3*face_len));   \
+    auto rhof_buff = Kokkos::subview(rbuf_d, Kokkos::make_pair(3*face_len,     \
+                                                               4*face_len));   \
+    SYNC_MPI_BUFFER(rbuf_d, rbuf_h);                                           \
+    Kokkos::MDRangePolicy<Kokkos::Rank<2>> x_##_face({1,1},{n##y_+1,n##z_+1}); \
+    Kokkos::parallel_for("end_recv_edge_hyb_jf<" #x_ #y_ #z_ ">", x_##_face,   \
+      KOKKOS_LAMBDA(const int y_, const int z_) {                              \
+        const int x_ = face;                                                   \
+        const int voxel = VOXEL(x,y,z,nx,ny,nz);                               \
+        k_field(voxel, field_var::jfx)  += jfx_buff( (z_-1)*n##y_ + (y_-1));   \
+        k_field(voxel, field_var::jfy)  += jfy_buff( (z_-1)*n##y_ + (y_-1));   \
+        k_field(voxel, field_var::jfz)  += jfz_buff( (z_-1)*n##y_ + (y_-1));   \
+        k_field(voxel, field_var::rhof) += rhof_buff((z_-1)*n##y_ + (y_-1));   \
+      });                                                                      \
   }
 
 /**

--- a/src/field_advance/standard/remote.cc
+++ b/src/field_advance/standard/remote.cc
@@ -3879,6 +3879,283 @@ k_end_remote_ghost_hyb_o(field_array_t* ALIGNED(128) fa,
 }
 
 /*****************************************************************************
+ * Edge value communications
+ *
+ * Like ghost communication routines, but opposite direction:
+ * Send ghost cell data, recv increment into live cells.
+ *****************************************************************************/
+
+//Hybrid edge JF
+#define BRP(x_,y_,z_)                                                   \
+  const int n##y_ = fa->g->n##y_, n##z_=fa->g->n##z_;                   \
+  const int size = (4*n##y_*n##z_)*sizeof(float);                       \
+  BEGIN_RECV_PORT_K(i,j,k,size,fa->g, rbuf_d, rbuf_h);
+
+/**
+ * @brief Begin non blocking receive for adding remote jf ghost cells into
+ * local jf edge cells, needed for quadratic-sum or higher-order particle
+ * shape.
+ *
+ * Calculates size of receive buffer based on which face and orientation.
+ * BRP macro adjusts calculations for different face directions. Template
+ * function wraps the BRP macro to make profiling clearer.
+ *
+ * @tparam Face Enum denoting the face and order of dimensions for calculations
+ * @param fa Pointer for field array structure containing field and grid data
+ * @param i X-dim face coordinate (-1.0: neg. x, 0: origin, 1.0: pos. x)
+ * @param j Y-dim face coordinate (-1.0: neg. y, 0: origin, 1.0: pos. y)
+ * @param k Z-dim face coordinate (-1.0: neg. z, 0: origin, 1.0: pos. z)
+ * @param rbuf_d Receive buffer on the device
+ * @param rbuf_h Mirror of rbuf_d on the Host
+ */
+template<typename Face>
+void
+begin_recv_edge_hyb_jf(field_array* fa, const int i, const int j, const int k) {
+  int src = fa->g->bc[BOUNDARY(-i,-j,-k)]; /**< Source rank */
+  // Only recv cells if src is a valid neighbor and not itself
+  if( 0 <= src && src < world_size ) {
+    Kokkos::DualView<float*> rbuf = fa->fb->recv_buffer[BOUNDARY(i,j,k)];
+    auto rbuf_d = rbuf.view<Kokkos::DefaultExecutionSpace>();
+    auto rbuf_h = rbuf.view<Kokkos::DefaultHostExecutionSpace>();
+    if constexpr (std::is_same<Face,XYZ>::value) {
+      BRP(x,y,z);
+    } else if constexpr (std::is_same<Face,YZX>::value) {
+      BRP(y,z,x);
+    } else if constexpr (std::is_same<Face,ZXY>::value) {
+      BRP(z,x,y);
+    }
+  }
+}
+
+#undef BRP
+
+#define BSP(x_,y_,z_)                                                   \
+  const int nx = fa->g->nx, ny = fa->g->ny, nz = fa->g->nz;             \
+  const int size = (4*n##y_*n##z_)*sizeof(float);                       \
+  const int face = (i+j+k)<0 ? 0 : n##x_+1; /* send ghosts to edges */  \
+  const k_field_t& k_field = fa->k_f_d;                                 \
+  Kokkos::MDRangePolicy<Kokkos::Rank<2>> x_##_face({1, 1}, {n##z_+1, n##y_+1}); \
+  Kokkos::parallel_for("begin_send_edge_hyb_jf<XYZ>", x_##_face, KOKKOS_LAMBDA(const int z_, const int y_) { \
+      const int x_ = face;                                              \
+      sbuf_d(                (z_-1)*n##y_ + (y_-1)) = k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfx); \
+      sbuf_d(  n##y_*n##z_ + (z_-1)*n##y_ + (y_-1)) = k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfy); \
+      sbuf_d(2*n##y_*n##z_ + (z_-1)*n##y_ + (y_-1)) = k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfz); \
+      sbuf_d(3*n##y_*n##z_ + (z_-1)*n##y_ + (y_-1)) = k_field(VOXEL(x,y,z,nx,ny,nz), field_var::rhof);\
+    });                                                                 \
+  SYNC_MPI_BUFFER(sbuf_h, sbuf_d);                                      \
+  BEGIN_SEND_PORT_K(i,j,k,size,fa->g, sbuf_d, sbuf_h);
+
+/**
+ * @brief Begin non blocking send for adding local jf ghost cells into remote
+ * jf edge cells, needed for quadratic-sum or higher-order particle shape.
+ *
+ * Serializes jf data in contiguous buffer and sends data to a neighbors
+ * ghost cells. BSP macro adjusts calculations for different face directions.
+ * Template function wraps the BRP macro to make profiling clearer.
+ *
+ * @tparam Face Enum denoting the face and order of dimensions for calculations
+ * @param fa Pointer for field array structure containing field and grid data
+ * @param i X-dim face coordinate (-1.0: neg. x, 0: origin, 1.0: pos. x)
+ * @param j Y-dim face coordinate (-1.0: neg. y, 0: origin, 1.0: pos. y)
+ * @param k Z-dim face coordinate (-1.0: neg. z, 0: origin, 1.0: pos. z)
+ * @param sbuf_d Send buffer on the device
+ * @param sbuf_h Mirror of sbuf_d on the Host
+ */
+template<typename Face>
+void
+begin_send_edge_hyb_jf(field_array* fa, const int i, const int j, const int k) {
+  int dst = fa->g->bc[BOUNDARY(i,j,k)]; /**< Destination rank */
+  // Only send cells if dst is a valid neighbor and not itself
+  if( 0 <= dst && dst < world_size ) {
+    Kokkos::DualView<float*> sbuf = fa->fb->send_buffer[BOUNDARY(i,j,k)];
+    auto sbuf_d = sbuf.view<Kokkos::DefaultExecutionSpace>();
+    auto sbuf_h = sbuf.view<Kokkos::DefaultHostExecutionSpace>();
+    if constexpr (std::is_same<Face,XYZ>::value) {
+      BSP(x,y,z);
+    } else if constexpr (std::is_same<Face,YZX>::value) {
+      BSP(y,z,x);
+    } else if constexpr (std::is_same<Face,ZXY>::value) {
+      BSP(z,x,y);
+    }
+  }
+}
+
+#undef BSP
+
+/**
+ * @brief Begin exchanging jf ghost cells between all neighbors to increment
+ * edge cells for quadratic-sum or higher-order particle particle shape.
+ *
+ * Prepares receive buffers, packs face cells into contiguous buffers
+ * and starts non blocking communication with neighbors. Only performs
+ * communication when necessary. Will ignore cases where the process is on a
+ * boundary or if the process topology would make the exchange redundant
+ * (ex. 1D and 2D grids).
+ *
+ * @param fa Pointer for field array structure containing field and grid data
+ * @param g Pointer to grid structure
+ * @param fb Reference to field buffers used for MPI communication
+ */
+void k_begin_remote_edge_hyb_jf(field_array_t* ALIGNED(128) fa,
+                                const grid_t* g,
+                                field_buffers_t& fb) {
+  // TODO halo exchange not yet implemented for ghost->edge summation.
+  // Need modified versions of begin/end_halo_exchange(...)
+  //         to pack local ghosts, unpack by adding to remote edges
+  // instead of pack local edges,  unpack by replacing remote ghosts.
+  // --ATr,2025aug30
+//#ifdef VPIC_ENABLE_HALO_EXCHANGE
+//  begin_halo_add_exchange(fa, field_var::jfx, field_var::rhof+1);
+//#else
+  // Start receiving
+  begin_recv_edge_hyb_jf<XYZ>(fa, -1,  0,  0);
+  begin_recv_edge_hyb_jf<YZX>(fa,  0, -1,  0);
+  begin_recv_edge_hyb_jf<ZXY>(fa,  0,  0, -1);
+  begin_recv_edge_hyb_jf<XYZ>(fa,  1,  0,  0);
+  begin_recv_edge_hyb_jf<YZX>(fa,  0,  1,  0);
+  begin_recv_edge_hyb_jf<ZXY>(fa,  0,  0,  1);
+
+  // Start sending
+  begin_send_edge_hyb_jf<XYZ>(fa, -1,  0,  0);
+  begin_send_edge_hyb_jf<YZX>(fa,  0, -1,  0);
+  begin_send_edge_hyb_jf<ZXY>(fa,  0,  0, -1);
+  begin_send_edge_hyb_jf<XYZ>(fa,  1,  0,  0);
+  begin_send_edge_hyb_jf<YZX>(fa,  0,  1,  0);
+  begin_send_edge_hyb_jf<ZXY>(fa,  0,  0,  1);
+//#endif
+}
+
+#define ERP(x_,y_,z_)                                                   \
+  const grid_t* g = fa->g;                                              \
+  float* p = reinterpret_cast<float*>(end_recv_port_k(i,j,k,g));        \
+  if(p) {                                                               \
+    const int nx = g->nx, ny = g->ny, nz = g->nz;                       \
+    const int face = (i+j+k) < 0 ? n##x_ : 1; /*add ghosts to edges*/   \
+    const k_field_t& k_field = fa->k_f_d;                               \
+    SYNC_MPI_BUFFER(rbuf_d, rbuf_h);                                    \
+    Kokkos::MDRangePolicy<Kokkos::Rank<2>> x_##_face({1, 1}, {n##z_+1, n##y_+1}); \
+    Kokkos::parallel_for("end_recv_edge_hyb_jf<XYZ>", x_##_face, KOKKOS_LAMBDA(const int z_, const int y_) { \
+        const int x_ = face;                                            \
+        k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfx)  += rbuf_d(                (z_-1)*n##y_ + (y_-1)); \
+        k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfy)  += rbuf_d(  n##y_*n##z_ + (z_-1)*n##y_ + (y_-1)); \
+        k_field(VOXEL(x,y,z,nx,ny,nz), field_var::jfz)  += rbuf_d(2*n##y_*n##z_ + (z_-1)*n##y_ + (y_-1)); \
+        k_field(VOXEL(x,y,z,nx,ny,nz), field_var::rhof) += rbuf_d(3*n##y_*n##z_ + (z_-1)*n##y_ + (y_-1)); \
+      });                                                               \
+  }
+
+/**
+ * @brief End non blocking receive for adding remote jf ghost cells into
+ * local jf edge cells, needed for quadratic-sum or higher-order particle
+ * shape.
+ *
+ * Wait for non blocking communication to complete and unpack the buffer into
+ * the local ranks edge cells. Wait and unpacking the buffer may be made to
+ * overlap between different faces in the future.
+ *
+ * @tparam Face Enum denoting the face and order of dimensions for calculations
+ * @param fa Pointer for field array structure containing field and grid data
+ * @param i X-dim face coordinate (-1.0: neg. x, 0: origin, 1.0: pos. x)
+ * @param j Y-dim face coordinate (-1.0: neg. y, 0: origin, 1.0: pos. y)
+ * @param k Z-dim face coordinate (-1.0: neg. z, 0: origin, 1.0: pos. z)
+ * @param rbuf_d Receive buffer on the device
+ * @param rbuf_h Mirror of rbuf_d on the Host
+ */
+template<typename Face>
+void
+end_recv_edge_hyb_jf(field_array_t* fa, const int i, const int j, const int k) {
+  int src = fa->g->bc[BOUNDARY(-i,-j,-k)]; /**< Source rank */
+  // Only recv cells if src is a valid neighbor and not itself
+  if( 0 <= src && src < world_size ) {
+    Kokkos::DualView<float*> rbuf = fa->fb->recv_buffer[BOUNDARY(i,j,k)];
+    auto rbuf_d = rbuf.view<Kokkos::DefaultExecutionSpace>();
+    auto rbuf_h = rbuf.view<Kokkos::DefaultHostExecutionSpace>();
+    if constexpr (std::is_same<Face,XYZ>::value) {
+      ERP(x,y,z);
+    } else if constexpr (std::is_same<Face,YZX>::value) {
+      ERP(y,z,x);
+    } else if constexpr (std::is_same<Face,ZXY>::value) {
+      ERP(z,x,y);
+    }
+  }
+}
+
+#undef ERP
+
+/**
+ * @brief End non blocking send for adding local jf ghost cells into remote jf
+ * edge cells, needed for quadratic-sum or higher-order particle shape.
+ *
+ * Ensures the prior send operation is complete and unsets the send buffer.
+ *
+ * @tparam Face Enum denoting the face and order of dimensions for calculations
+ * @param fa Pointer for field array structure containing field and grid data
+ * @param i X-dim face coordinate (-1.0: neg. x, 0: origin, 1.0: pos. x)
+ * @param j Y-dim face coordinate (-1.0: neg. y, 0: origin, 1.0: pos. y)
+ * @param k Z-dim face coordinate (-1.0: neg. z, 0: origin, 1.0: pos. z)
+ */
+template<typename Face>
+void
+end_send_edge_hyb_jf(field_array_t* fa, const int i, const int j, const int k) {
+  int dst = fa->g->bc[BOUNDARY(i,j,k)]; /**< Destination rank */
+  // Only send cells if dst is a valid neighbor and not itself
+  if( 0 <= dst && dst < world_size ) {
+    if constexpr (std::is_same<Face,XYZ>::value) {
+      end_send_port_k(i,j,k,fa->g);
+    } else if constexpr (std::is_same<Face,YZX>::value) {
+      end_send_port_k(i,j,k,fa->g);
+    } else if constexpr (std::is_same<Face,ZXY>::value) {
+      end_send_port_k(i,j,k,fa->g);
+    }
+  }
+}
+
+/**
+ * @brief End exchanging jf ghost cells between all neighbors to increment
+ * edge cells for quadratic-sum or higher-order particle particle shape.
+ *
+ * Wait until MPI communication is complete then unpack the buffers and
+ * fill in the ghost cells with the communicated smoothing variables. Only
+ * performs communication when necessary. Will ignore cases where the process
+ * is on a boundary or if the process topology would make the exchange redundant
+ * (ex. 1D and 2D grids).
+ *
+ * @param fa Pointer for field array structure containing field and grid data
+ * @param g Pointer to grid structure
+ * @param fb Reference to field buffers used for MPI communication
+ */
+void
+k_end_remote_edge_hyb_jf(field_array_t* ALIGNED(128) fa,
+                         const grid_t* g,
+                         field_buffers_t& fb) {
+  // TODO halo exchange not yet implemented for ghost->edge summation.
+  // Need modified versions of begin/end_halo_exchange(...)
+  //         to pack local ghosts, unpack by adding to remote edges
+  // instead of pack local edges,  unpack by replacing remote ghosts.
+  // --ATr,2025aug30
+//#ifdef VPIC_ENABLE_HALO_EXCHANGE
+//  end_halo_add_exchange(fa, field_var::jfx, field_var::rhof+1);
+//#else
+  // End receiving
+  end_recv_edge_hyb_jf<XYZ>(fa, -1,  0,  0);
+  end_recv_edge_hyb_jf<YZX>(fa,  0, -1,  0);
+  end_recv_edge_hyb_jf<ZXY>(fa,  0,  0, -1);
+  end_recv_edge_hyb_jf<XYZ>(fa,  1,  0,  0);
+  end_recv_edge_hyb_jf<YZX>(fa,  0,  1,  0);
+  end_recv_edge_hyb_jf<ZXY>(fa,  0,  0,  1);
+
+  // End sending
+  end_send_edge_hyb_jf<XYZ>(fa, -1,  0,  0);
+  end_send_edge_hyb_jf<YZX>(fa,  0, -1,  0);
+  end_send_edge_hyb_jf<ZXY>(fa,  0,  0, -1);
+  end_send_edge_hyb_jf<XYZ>(fa,  1,  0,  0);
+  end_send_edge_hyb_jf<YZX>(fa,  0,  1,  0);
+  end_send_edge_hyb_jf<ZXY>(fa,  0,  0,  1);
+
+  Kokkos::fence();
+//#endif
+}
+
+/*****************************************************************************
  * Synchronization functions
  *
  * The communication is done in three passes so that small edge and corner

--- a/src/field_advance/standard/sfa_private.h
+++ b/src/field_advance/standard/sfa_private.h
@@ -425,42 +425,44 @@ local_ghost_tang_b( field_t      * ALIGNED(128) f,
                     const grid_t *              g );
 
 void
-k_local_ghost_tang_b(field_array_t * RESTRICT f,
-                    const grid_t * g);
+k_local_ghost_tang_b( field_array_t * RESTRICT f,
+                       const grid_t *          g );
 
 void
 local_ghost_norm_e( field_t      * ALIGNED(128) f,
                     const grid_t *              g );
+
 void
-k_local_ghost_norm_e( field_array_t      * ALIGNED(128) f,
-                    const grid_t *              g );
+k_local_ghost_norm_e( field_array_t * ALIGNED(128) f,
+                       const grid_t *              g );
 
 void
 local_ghost_div_b( field_t      * ALIGNED(128) f,
                    const grid_t *              g );
 
 void
-k_local_ghost_div_b( field_array_t      * ALIGNED(128) f,
-                   const grid_t *              g );
+k_local_ghost_div_b( field_array_t * ALIGNED(128) f,
+                      const grid_t *              g );
 
 void
 local_adjust_tang_e( field_t      * ALIGNED(128) f,
                      const grid_t *              g );
 
 void
-k_local_adjust_tang_e(field_array_t* RESTRICT f,
-                        const grid_t* g);
+k_local_adjust_tang_e( field_array_t * RESTRICT f,
+                        const grid_t *          g );
 
 void
 local_adjust_div_e( field_t      * ALIGNED(128) f,
                     const grid_t *              g );
+
 void
-k_local_adjust_div_e( field_array_t      * ALIGNED(128) f,
-                    const grid_t *              g );
+k_local_adjust_div_e( field_array_t * ALIGNED(128) f,
+                       const grid_t *              g );
 
 void
 k_local_adjust_norm_b( field_array_t * RESTRICT fa,
-                     const grid_t *              g );
+                        const grid_t *           g );
 
 void
 local_adjust_norm_b( field_t      * ALIGNED(128) f,
@@ -482,36 +484,36 @@ local_adjust_rhob( field_t      * ALIGNED(128) f,
                    const grid_t *              g );
 
 void
-k_local_adjust_rhof(field_array_t* ALIGNED(128) f,
-                    const grid_t*               g);
+k_local_adjust_rhof( field_array_t * ALIGNED(128) f,
+                      const grid_t *              g );
 
 void
-k_local_adjust_rhob(field_array_t* ALIGNED(128) f,
-                    const grid_t*               g);
+k_local_adjust_rhob(field_array_t * ALIGNED(128) f,
+                     const grid_t *              g );
 
 void
-k_local_adjust_jf( field_array_t      * ALIGNED(128) f,
-                 const grid_t *              g );
+k_local_adjust_jf( field_array_t * ALIGNED(128) f,
+                    const grid_t *              g );
 
 void
-k_hyb_local_ghost_e( field_array_t      * RESTRICT f,
-		     const grid_t *              g );
+k_hyb_local_ghost_e( field_array_t * RESTRICT f,
+                      const grid_t *          g );
 
 void
-k_hyb_local_ghost_b( field_array_t      * RESTRICT f,
-		     const grid_t *              g );
-		     
-		     void
-k_hyb_local_ghost_jf( field_array_t      * RESTRICT f,
-		     const grid_t *              g );
-		     
-		     		     void
-k_hyb_local_ghost_ot( field_array_t      * RESTRICT f,
-		     const grid_t *              g );
-		     
-		     		     		     void
-k_hyb_local_ghost_lapl_b( field_array_t      * RESTRICT f,
-		     const grid_t *              g );
+k_hyb_local_ghost_b( field_array_t * RESTRICT f,
+                      const grid_t *          g );
+
+void
+k_hyb_local_ghost_jf( field_array_t * RESTRICT f,
+                       const grid_t *          g );
+
+void
+k_hyb_local_ghost_ot( field_array_t * RESTRICT f,
+                       const grid_t *          g );
+
+void
+k_hyb_local_ghost_lapl_b( field_array_t * RESTRICT f,
+                           const grid_t *          g );
 
 // In remote.c
 

--- a/src/field_advance/standard/sfa_private.h
+++ b/src/field_advance/standard/sfa_private.h
@@ -515,6 +515,10 @@ void
 k_hyb_local_ghost_lapl_b( field_array_t * RESTRICT f,
                            const grid_t *          g );
 
+void
+k_hyb_local_adjust_jf( field_array_t * RESTRICT f,
+                        const grid_t *          g );
+
 // In remote.c
 
 void

--- a/src/field_advance/standard/sfa_private.h
+++ b/src/field_advance/standard/sfa_private.h
@@ -655,5 +655,14 @@ k_end_remote_ghost_hyb_o( field_array_t      * ALIGNED(128) f,
                         const grid_t *              g,
                         field_buffers_t& f_buffers );
 
+void
+k_begin_remote_edge_hyb_jf( field_array_t      * ALIGNED(128) f,
+                            const grid_t *              g,
+                            field_buffers_t& f_buffers );
+void
+k_end_remote_edge_hyb_jf( field_array_t      * ALIGNED(128) f,
+                        const grid_t *              g,
+                        field_buffers_t& f_buffers );
+
 
 #endif // _sfa_private_h_

--- a/src/sf_interface/interpolator_array.cc
+++ b/src/sf_interface/interpolator_array.cc
@@ -472,21 +472,9 @@ interpolator_array_t::copy_to_host() {
       host_interp[i].ex       = k_interpolator_h(i, interpolator_var::ex);
       host_interp[i].ey       = k_interpolator_h(i, interpolator_var::ey);
       host_interp[i].ez       = k_interpolator_h(i, interpolator_var::ez);
-      host_interp[i].dexdy    = k_interpolator_h(i, interpolator_var::dexdy);
-      host_interp[i].dexdz    = k_interpolator_h(i, interpolator_var::dexdz);
-      host_interp[i].d2exdydz = k_interpolator_h(i, interpolator_var::d2exdydz);
-      host_interp[i].deydz    = k_interpolator_h(i, interpolator_var::deydz);
-      host_interp[i].deydx    = k_interpolator_h(i, interpolator_var::deydx);
-      host_interp[i].d2eydzdx = k_interpolator_h(i, interpolator_var::d2eydzdx);
-      host_interp[i].dezdx    = k_interpolator_h(i, interpolator_var::dezdx);
-      host_interp[i].dezdy    = k_interpolator_h(i, interpolator_var::dezdy);
-      host_interp[i].d2ezdxdy = k_interpolator_h(i, interpolator_var::d2ezdxdy);
       host_interp[i].cbx      = k_interpolator_h(i, interpolator_var::cbx);
       host_interp[i].cby      = k_interpolator_h(i, interpolator_var::cby);
       host_interp[i].cbz      = k_interpolator_h(i, interpolator_var::cbz);
-      host_interp[i].dcbxdx   = k_interpolator_h(i, interpolator_var::dcbxdx);
-      host_interp[i].dcbydy   = k_interpolator_h(i, interpolator_var::dcbydy);
-      host_interp[i].dcbzdz   = k_interpolator_h(i, interpolator_var::dcbzdz);
 #else
 #ifdef SHAPE_QS
       host_interp[i].ex      = k_interpolator_h(i, interpolator_var::ex     );
@@ -551,21 +539,9 @@ interpolator_array_t::copy_to_device() {
       k_interpolator_h(i, interpolator_var::ex)       = host_interp[i].ex;
       k_interpolator_h(i, interpolator_var::ey)       = host_interp[i].ey;
       k_interpolator_h(i, interpolator_var::ez)       = host_interp[i].ez;
-      k_interpolator_h(i, interpolator_var::dexdy)    = host_interp[i].dexdy;
-      k_interpolator_h(i, interpolator_var::dexdz)    = host_interp[i].dexdz;
-      k_interpolator_h(i, interpolator_var::d2exdydz) = host_interp[i].d2exdydz;
-      k_interpolator_h(i, interpolator_var::deydz)    = host_interp[i].deydz;
-      k_interpolator_h(i, interpolator_var::deydx)    = host_interp[i].deydx;
-      k_interpolator_h(i, interpolator_var::d2eydzdx) = host_interp[i].d2eydzdx;
-      k_interpolator_h(i, interpolator_var::dezdx)    = host_interp[i].dezdx;
-      k_interpolator_h(i, interpolator_var::dezdy)    = host_interp[i].dezdy;
-      k_interpolator_h(i, interpolator_var::d2ezdxdy) = host_interp[i].d2ezdxdy;
       k_interpolator_h(i, interpolator_var::cbx)      = host_interp[i].cbx;
       k_interpolator_h(i, interpolator_var::cby)      = host_interp[i].cby;
       k_interpolator_h(i, interpolator_var::cbz)      = host_interp[i].cbz;
-      k_interpolator_h(i, interpolator_var::dcbxdx)   = host_interp[i].dcbxdx;
-      k_interpolator_h(i, interpolator_var::dcbydy)   = host_interp[i].dcbydy;
-      k_interpolator_h(i, interpolator_var::dcbzdz)   = host_interp[i].dcbzdz;
 #else
 #ifdef SHAPE_QS
       k_interpolator_h(i, interpolator_var::ex      ) = host_interp[i].ex     ;

--- a/src/sf_interface/interpolator_array.cc
+++ b/src/sf_interface/interpolator_array.cc
@@ -42,7 +42,9 @@ delete_interpolator_array( interpolator_array_t * ia ) {
   //FREE( ia );
 }
 
-void load_interpolator_array_kokkos(k_interpolator_t k_interp, k_field_t k_field, int nx, int ny, int nz) {
+void 
+load_interpolator_array_kokkos(k_interpolator_t k_interp, k_field_t k_field, 
+                               int nx, int ny, int nz) {
 
   #define pi_ex       k_interp(pi_index, interpolator_var::ex)
   #define pi_dexdx    k_interp(pi_index, interpolator_var::dexdx)
@@ -87,170 +89,140 @@ void load_interpolator_array_kokkos(k_interpolator_t k_interp, k_field_t k_field
   #define pi_d2cbzdy  k_interp(pi_index, interpolator_var::d2cbzdy)
   #define pi_d2cbzdz  k_interp(pi_index, interpolator_var::d2cbzdz)
 
-  const float twelfth = 1./12.;
-  const float sixth   = 1./6.;
-  const float half    = 0.5;
-  const float two     = 2.0;
-  const float six     = 6.;
+  constexpr float twelfth = 1./12.;
+  constexpr float sixth   = 1./6.;
 
-    Kokkos::MDRangePolicy<Kokkos::Rank<3>> load_policy({1, 1, 1}, {nz+1, ny+1, nx+1});
-    Kokkos::parallel_for("load interpolator", load_policy, KOKKOS_LAMBDA(const int z, const int y, const int x) {
-        int pi_index = VOXEL(1,   y,   z, nx,ny,nz) + x-1; //pi = &fi(1,y,z);
-        int pf0_index = VOXEL(1,  y,   z, nx,ny,nz) + x-1; //pf0 = &f(1,y,z);
-        int pfx_index = VOXEL(2,  y,   z, nx,ny,nz) + x-1; //pfx = &f(2,y,z);
-        int pfy_index = VOXEL(1,  y+1, z, nx,ny,nz) + x-1; //pfy = &f(1,y+1,z);
-        int pfz_index = VOXEL(1,  y,   z+1, nx,ny,nz) + x-1; //pfz = &f(1,y,z+1);
-        int pfmx_index = VOXEL(x-1, y,   z,   nx,ny,nz);
-        int pfmy_index = VOXEL(x,   y-1, z,   nx,ny,nz);
-        int pfmz_index = VOXEL(x,   y,   z-1, nx,ny,nz);
-
-        // ex interpolation coefficients
-        // ex->tx from hyb_smooth_eb(...)
-        auto w0  = k_field(pf0_index,  field_var::tx);
-        auto wx  = k_field(pfx_index,  field_var::tx);
-        auto wy  = k_field(pfy_index,  field_var::tx);
-        auto wz  = k_field(pfz_index,  field_var::tx);
-        auto wmx = k_field(pfmx_index, field_var::tx);
-        auto wmy = k_field(pfmy_index, field_var::tx);
-        auto wmz = k_field(pfmz_index, field_var::tx);
+  Kokkos::MDRangePolicy<Kokkos::Rank<3>> load_policy({1, 1, 1}, {nx+1, ny+1, nz+1});
+  Kokkos::parallel_for("load interpolator", load_policy, KOKKOS_LAMBDA(const int x, const int y, const int z) {
+      const int pi_index   = VOXEL(x,   y,   z,   nx,ny,nz); 
+      const int pf0_index  = VOXEL(x,   y,   z,   nx,ny,nz); 
+      const int pfx_index  = VOXEL(x+1, y,   z,   nx,ny,nz); 
+      const int pfy_index  = VOXEL(x,   y+1, z,   nx,ny,nz); 
+      const int pfz_index  = VOXEL(x,   y,   z+1, nx,ny,nz); 
+      const int pfmx_index = VOXEL(x-1, y,   z,   nx,ny,nz);
+      const int pfmy_index = VOXEL(x,   y-1, z,   nx,ny,nz);
+      const int pfmz_index = VOXEL(x,   y,   z-1, nx,ny,nz);
 
 #ifdef SHAPE_NGP
-        pi_ex     = w0;
-#else
-#ifdef SHAPE_QS
-        pi_ex     = twelfth*(six*w0 + wx + wy + wz + wmx + wmy + wmz);
-        pi_dexdx  = sixth*(wx - wmx);
-        pi_dexdy  = sixth*(wy - wmy);
-        pi_dexdz  = sixth*(wz - wmz);
-        pi_d2exdx = twelfth*(wx + wmx - two*w0);
-        pi_d2exdy = twelfth*(wy + wmy - two*w0);
-        pi_d2exdz = twelfth*(wz + wmz - two*w0);
-#endif
-#endif
+      // ex interpolation coefficients
+      // ex->tx from hyb_smooth_eb(...)
+      pi_ex = k_field(pf0_index, field_var::tx);
+      // ey interpolation coefficients
+      // ey->ty from hyb_smooth_eb(...)
+      pi_ey = k_field(pf0_index, field_var::ty);
+      // ez interpolation coefficients
+      // ez->tz from hyb_smooth_eb(...)
+      pi_ez = k_field(pf0_index, field_var::tz);
 
-        // ey interpolation coefficients
-        // ey->ty from hyb_smooth_eb(...)
-        w0  = k_field(pf0_index,  field_var::ty);
-        wx  = k_field(pfx_index,  field_var::ty);
-        wy  = k_field(pfy_index,  field_var::ty);
-        wz  = k_field(pfz_index,  field_var::ty);
-        wmx = k_field(pfmx_index, field_var::ty);
-        wmy = k_field(pfmy_index, field_var::ty);
-        wmz = k_field(pfmz_index, field_var::ty);
+      // bx interpolation coefficients
+      // cbx->ox from hyb_smooth_eb(...)
+      pi_cbx = k_field(pf0_index, field_var::ox) + k_field(pf0_index, field_var::cbx0);
+      // by interpolation coefficients
+      // cby->oy from hyb_smooth_eb(...)
+      pi_cby = k_field(pf0_index, field_var::oy) + k_field(pf0_index, field_var::cby0);
+      // bz interpolation coefficients
+      // cbz->oz from hyb_smooth_eb(...)
+      pi_cbz = k_field(pf0_index, field_var::oz) + k_field(pf0_index, field_var::cbz0);
+#elif defined( SHAPE_QS )
+      // ex interpolation coefficients
+      // ex->tx from hyb_smooth_eb(...)
+      auto w0  = k_field(pf0_index,  field_var::tx);
+      auto wx  = k_field(pfx_index,  field_var::tx);
+      auto wy  = k_field(pfy_index,  field_var::tx);
+      auto wz  = k_field(pfz_index,  field_var::tx);
+      auto wmx = k_field(pfmx_index, field_var::tx);
+      auto wmy = k_field(pfmy_index, field_var::tx);
+      auto wmz = k_field(pfmz_index, field_var::tx);
+      pi_ex     = twelfth*(6.f*w0 + wx + wy + wz + wmx + wmy + wmz);
+      pi_dexdx  = sixth*(wx - wmx);
+      pi_dexdy  = sixth*(wy - wmy);
+      pi_dexdz  = sixth*(wz - wmz);
+      pi_d2exdx = twelfth*(wx + wmx - 2.f*w0);
+      pi_d2exdy = twelfth*(wy + wmy - 2.f*w0);
+      pi_d2exdz = twelfth*(wz + wmz - 2.f*w0);
+      // ey interpolation coefficients
+      // ey->ty from hyb_smooth_eb(...)
+      w0  = k_field(pf0_index,  field_var::ty);
+      wx  = k_field(pfx_index,  field_var::ty);
+      wy  = k_field(pfy_index,  field_var::ty);
+      wz  = k_field(pfz_index,  field_var::ty);
+      wmx = k_field(pfmx_index, field_var::ty);
+      wmy = k_field(pfmy_index, field_var::ty);
+      wmz = k_field(pfmz_index, field_var::ty);
+      pi_ey     = twelfth*(6.f*w0 + wx + wy + wz + wmx + wmy + wmz);
+      pi_deydx  = sixth*(wx - wmx);
+      pi_deydy  = sixth*(wy - wmy);
+      pi_deydz  = sixth*(wz - wmz);
+      pi_d2eydx = twelfth*(wx + wmx - 2.f*w0);
+      pi_d2eydy = twelfth*(wy + wmy - 2.f*w0);
+      pi_d2eydz = twelfth*(wz + wmz - 2.f*w0);
+      // ez interpolation coefficients
+      // ez->tz from hyb_smooth_eb(...)
+      w0  = k_field(pf0_index,  field_var::tz);
+      wx  = k_field(pfx_index,  field_var::tz);
+      wy  = k_field(pfy_index,  field_var::tz);
+      wz  = k_field(pfz_index,  field_var::tz);
+      wmx = k_field(pfmx_index, field_var::tz);
+      wmy = k_field(pfmy_index, field_var::tz);
+      wmz = k_field(pfmz_index, field_var::tz);
+      pi_ez     = twelfth*(6.f*w0 + wx + wy + wz + wmx + wmy + wmz);
+      pi_dezdx  = sixth*(wx - wmx);
+      pi_dezdy  = sixth*(wy - wmy);
+      pi_dezdz  = sixth*(wz - wmz);
+      pi_d2ezdx = twelfth*(wx + wmx - 2.f*w0);
+      pi_d2ezdy = twelfth*(wy + wmy - 2.f*w0);
+      pi_d2ezdz = twelfth*(wz + wmz - 2.f*w0);
 
-#ifdef SHAPE_NGP
-        pi_ey     = w0;
-#else
-#ifdef SHAPE_QS
-        pi_ey     = twelfth*(six*w0 + wx + wy + wz + wmx + wmy + wmz);
-        pi_deydx  = sixth*(wx - wmx);
-        pi_deydy  = sixth*(wy - wmy);
-        pi_deydz  = sixth*(wz - wmz);
-        pi_d2eydx = twelfth*(wx + wmx - two*w0);
-        pi_d2eydy = twelfth*(wy + wmy - two*w0);
-        pi_d2eydz = twelfth*(wz + wmz - two*w0);
+      // bx interpolation coefficients
+      // cbx->ox from hyb_smooth_eb(...)
+      w0  = k_field(pf0_index,  field_var::ox) + k_field(pf0_index,  field_var::cbx0);
+      wx  = k_field(pfx_index,  field_var::ox) + k_field(pfx_index,  field_var::cbx0);
+      wy  = k_field(pfy_index,  field_var::ox) + k_field(pfy_index,  field_var::cbx0);
+      wz  = k_field(pfz_index,  field_var::ox) + k_field(pfz_index,  field_var::cbx0);
+      wmx = k_field(pfmx_index, field_var::ox) + k_field(pfmx_index, field_var::cbx0);
+      wmy = k_field(pfmy_index, field_var::ox) + k_field(pfmy_index, field_var::cbx0);
+      wmz = k_field(pfmz_index, field_var::ox) + k_field(pfmz_index, field_var::cbx0);
+      pi_cbx     = twelfth*(6.f*w0 + wx + wy + wz + wmx + wmy + wmz);
+      pi_dcbxdx  = sixth*(wx - wmx);
+      pi_dcbxdy  = sixth*(wy - wmy);
+      pi_dcbxdz  = sixth*(wz - wmz);
+      pi_d2cbxdx = twelfth*(wx + wmx - 2.f*w0);
+      pi_d2cbxdy = twelfth*(wy + wmy - 2.f*w0);
+      pi_d2cbxdz = twelfth*(wz + wmz - 2.f*w0);
+      // by interpolation coefficients
+      // cby->oy from hyb_smooth_eb(...)
+      w0  = k_field(pf0_index,  field_var::oy) + k_field(pf0_index,  field_var::cby0);
+      wx  = k_field(pfx_index,  field_var::oy) + k_field(pfx_index,  field_var::cby0);
+      wy  = k_field(pfy_index,  field_var::oy) + k_field(pfy_index,  field_var::cby0);
+      wz  = k_field(pfz_index,  field_var::oy) + k_field(pfz_index,  field_var::cby0);
+      wmx = k_field(pfmx_index, field_var::oy) + k_field(pfmx_index, field_var::cby0);
+      wmy = k_field(pfmy_index, field_var::oy) + k_field(pfmy_index, field_var::cby0);
+      wmz = k_field(pfmz_index, field_var::oy) + k_field(pfmz_index, field_var::cby0);
+      pi_cby     = twelfth*(6.f*w0 + wx + wy + wz + wmx + wmy + wmz);
+      pi_dcbydx  = sixth*(wx - wmx);
+      pi_dcbydy  = sixth*(wy - wmy);
+      pi_dcbydz  = sixth*(wz - wmz);
+      pi_d2cbydx = twelfth*(wx + wmx - 2.f*w0);
+      pi_d2cbydy = twelfth*(wy + wmy - 2.f*w0);
+      pi_d2cbydz = twelfth*(wz + wmz - 2.f*w0);
+      // bz interpolation coefficients
+      // cbz->oz from hyb_smooth_eb(...)
+      w0  = k_field(pf0_index,  field_var::oz) + k_field(pf0_index,  field_var::cbz0);
+      wx  = k_field(pfx_index,  field_var::oz) + k_field(pfx_index,  field_var::cbz0);
+      wy  = k_field(pfy_index,  field_var::oz) + k_field(pfy_index,  field_var::cbz0);
+      wz  = k_field(pfz_index,  field_var::oz) + k_field(pfz_index,  field_var::cbz0);
+      wmx = k_field(pfmx_index, field_var::oz) + k_field(pfmx_index, field_var::cbz0);
+      wmy = k_field(pfmy_index, field_var::oz) + k_field(pfmy_index, field_var::cbz0);
+      wmz = k_field(pfmz_index, field_var::oz) + k_field(pfmz_index, field_var::cbz0);
+      pi_cbz     = twelfth*(6.f*w0 + wx + wy + wz + wmx + wmy + wmz);
+      pi_dcbzdx  = sixth*(wx - wmx);
+      pi_dcbzdy  = sixth*(wy - wmy);
+      pi_dcbzdz  = sixth*(wz - wmz);
+      pi_d2cbzdx = twelfth*(wx + wmx - 2.f*w0);
+      pi_d2cbzdy = twelfth*(wy + wmy - 2.f*w0);
+      pi_d2cbzdz = twelfth*(wz + wmz - 2.f*w0);
 #endif
-#endif
-
-        // ez interpolation coefficients
-        // ez->tz from hyb_smooth_eb(...)
-        w0  = k_field(pf0_index,  field_var::tz);
-        wx  = k_field(pfx_index,  field_var::tz);
-        wy  = k_field(pfy_index,  field_var::tz);
-        wz  = k_field(pfz_index,  field_var::tz);
-        wmx = k_field(pfmx_index, field_var::tz);
-        wmy = k_field(pfmy_index, field_var::tz);
-        wmz = k_field(pfmz_index, field_var::tz);
-
-#ifdef SHAPE_NGP
-        pi_ez     = w0;
-#else
-#ifdef SHAPE_QS
-        pi_ez     = twelfth*(six*w0 + wx + wy + wz + wmx + wmy + wmz);
-        pi_dezdx  = sixth*(wx - wmx);
-        pi_dezdy  = sixth*(wy - wmy);
-        pi_dezdz  = sixth*(wz - wmz);
-        pi_d2ezdx = twelfth*(wx + wmx - two*w0);
-        pi_d2ezdy = twelfth*(wy + wmy - two*w0);
-        pi_d2ezdz = twelfth*(wz + wmz - two*w0);
-#endif
-#endif
-
-        // bx interpolation coefficients
-        // cbx->ox from hyb_smooth_eb(...)
-        w0  = k_field(pf0_index,  field_var::ox) + k_field(pf0_index,  field_var::cbx0);
-        wx  = k_field(pfx_index,  field_var::ox) + k_field(pfx_index,  field_var::cbx0);
-        wy  = k_field(pfy_index,  field_var::ox) + k_field(pfy_index,  field_var::cbx0);
-        wz  = k_field(pfz_index,  field_var::ox) + k_field(pfz_index,  field_var::cbx0);
-        wmx = k_field(pfmx_index, field_var::ox) + k_field(pfmx_index, field_var::cbx0);
-        wmy = k_field(pfmy_index, field_var::ox) + k_field(pfmy_index, field_var::cbx0);
-        wmz = k_field(pfmz_index, field_var::ox) + k_field(pfmz_index, field_var::cbx0);
-
-#ifdef SHAPE_NGP
-        pi_cbx     = w0;
-#else
-#ifdef SHAPE_QS
-        pi_cbx     = twelfth*(six*w0 + wx + wy + wz + wmx + wmy + wmz);
-        pi_dcbxdx  = sixth*(wx - wmx);
-        pi_dcbxdy  = sixth*(wy - wmy);
-        pi_dcbxdz  = sixth*(wz - wmz);
-        pi_d2cbxdx = twelfth*(wx + wmx - two*w0);
-        pi_d2cbxdy = twelfth*(wy + wmy - two*w0);
-        pi_d2cbxdz = twelfth*(wz + wmz - two*w0);
-#endif
-#endif
-
-        // by interpolation coefficients
-        // cby->oy from hyb_smooth_eb(...)
-        w0  = k_field(pf0_index,  field_var::oy) + k_field(pf0_index,  field_var::cby0);
-        wx  = k_field(pfx_index,  field_var::oy) + k_field(pfx_index,  field_var::cby0);
-        wy  = k_field(pfy_index,  field_var::oy) + k_field(pfy_index,  field_var::cby0);
-        wz  = k_field(pfz_index,  field_var::oy) + k_field(pfz_index,  field_var::cby0);
-        wmx = k_field(pfmx_index, field_var::oy) + k_field(pfmx_index, field_var::cby0);
-        wmy = k_field(pfmy_index, field_var::oy) + k_field(pfmy_index, field_var::cby0);
-        wmz = k_field(pfmz_index, field_var::oy) + k_field(pfmz_index, field_var::cby0);
-
-#ifdef SHAPE_NGP
-        pi_cby     = w0;
-#else
-#ifdef SHAPE_QS
-        pi_cby     = twelfth*(six*w0 + wx + wy + wz + wmx + wmy + wmz);
-        pi_dcbydx  = sixth*(wx - wmx);
-        pi_dcbydy  = sixth*(wy - wmy);
-        pi_dcbydz  = sixth*(wz - wmz);
-        pi_d2cbydx = twelfth*(wx + wmx - two*w0);
-        pi_d2cbydy = twelfth*(wy + wmy - two*w0);
-        pi_d2cbydz = twelfth*(wz + wmz - two*w0);
-#endif
-#endif
-
-        // bz interpolation coefficients
-        // cbz->oz from hyb_smooth_eb(...)
-        w0  = k_field(pf0_index,  field_var::oz) + k_field(pf0_index,  field_var::cbz0);
-        wx  = k_field(pfx_index,  field_var::oz) + k_field(pfx_index,  field_var::cbz0);
-        wy  = k_field(pfy_index,  field_var::oz) + k_field(pfy_index,  field_var::cbz0);
-        wz  = k_field(pfz_index,  field_var::oz) + k_field(pfz_index,  field_var::cbz0);
-        wmx = k_field(pfmx_index, field_var::oz) + k_field(pfmx_index, field_var::cbz0);
-        wmy = k_field(pfmy_index, field_var::oz) + k_field(pfmy_index, field_var::cbz0);
-        wmz = k_field(pfmz_index, field_var::oz) + k_field(pfmz_index, field_var::cbz0);
-
-#ifdef SHAPE_NGP
-        pi_cbz     = w0;
-#else
-#ifdef SHAPE_QS
-        pi_cbz     = twelfth*(six*w0 + wx + wy + wz + wmx + wmy + wmz);
-        pi_dcbzdx  = sixth*(wx - wmx);
-        pi_dcbzdy  = sixth*(wy - wmy);
-        pi_dcbzdz  = sixth*(wz - wmz);
-        pi_d2cbzdx = twelfth*(wx + wmx - two*w0);
-        pi_d2cbzdy = twelfth*(wy + wmy - two*w0);
-        pi_d2cbzdz = twelfth*(wz + wmz - two*w0);
-#endif
-#endif
-
-        //pi++; pf0++; pfx++; pfy++; pfz++; pfyz++; pfzx++; pfxy++;
-
-    }); // end Kokkos::parallel_for("load interpolator")
+  }); // end Kokkos::parallel_for("load interpolator")
 
   #undef pi_ex
   #undef pi_dexdx
@@ -294,149 +266,6 @@ void load_interpolator_array_kokkos(k_interpolator_t k_interp, k_field_t k_field
   #undef pi_d2cbzdx
   #undef pi_d2cbzdy
   #undef pi_d2cbzdz
-
-/*
-    Kokkos::parallel_for("load interpolator", KOKKOS_TEAM_POLICY_DEVICE
-      (nz, Kokkos::AUTO),
-      KOKKOS_LAMBDA
-      (const KOKKOS_TEAM_POLICY_DEVICE::member_type &team_member) {
-    const unsigned int z = team_member.league_rank() + 1;
-
-    //for( z=1; z<=nz; z++ ) {
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team_member, ny), [=] (int yi) {
-      const unsigned int y = yi + 1;
-
-      //for( x=1; x<=nx; x++ ) {
-      Kokkos::parallel_for(Kokkos::ThreadVectorRange(team_member, nx), [=] (int x) {
-
-        //pi = &fi(1,y,z);
-        int pi_index = VOXEL(1,   y,   z, nx,ny,nz) + x;
-
-        //pf0 = &f(1,y,z);
-        int pf0_index = VOXEL(1,  y,   z, nx,ny,nz) + x;
-
-        //pfx = &f(2,y,z);
-        int pfx_index = VOXEL(2,  y,   z, nx,ny,nz) + x;
-
-        //pfy = &f(1,y+1,z);
-        int pfy_index = VOXEL(1,  y+1, z, nx,ny,nz) + x;
-
-        //pfz = &f(1,y,z+1);
-        int pfz_index = VOXEL(1,  y,   z+1, nx,ny,nz) + x;
-
-        //pfyz = &f(1,y+1,z+1);
-        int pfyz_index = VOXEL(1, y+1, z+1, nx,ny,nz) + x;
-
-        //pfzx = &f(2,y,z+1);
-        int pfzx_index = VOXEL(2, y,   z+1, nx,ny,nz) + x;
-
-        //pfxy = &f(2,y+1,z);
-        int pfxy_index = VOXEL(2, y+1, z, nx,ny,nz) + x;
-
-        // ex interpolation coefficients
-        //w0 = pf0->ex;
-        #define w0 k_field(pf0_index, field_var::ex)
-        //w1 = pfy->ex;
-        #define w1 k_field(pfy_index, field_var::ex)
-        //w2 = pfz->ex;
-        #define w2 k_field(pfz_index, field_var::ex)
-        //w3 = pfyz->ex;
-        #define w3 k_field(pfyz_index, field_var::ex)
-
-        pi_ex       = fourth*( (w3 + w0) + (w1 + w2) );
-        pi_dexdy    = fourth*( (w3 - w0) + (w1 - w2) );
-        pi_dexdz    = fourth*( (w3 - w0) - (w1 - w2) );
-        pi_d2exdydz = fourth*( (w3 + w0) - (w1 + w2) );
-
-        #undef w0
-        #undef w1
-        #undef w2
-        #undef w3
-
-        // ey interpolation coefficients
-
-        //w0 = pf0->ey;
-        #define w0 k_field(pf0_index, field_var::ey)
-        //w1 = pfz->ey;
-        #define w1 k_field(pfz_index, field_var::ey)
-        //w2 = pfx->ey;
-        #define w2 k_field(pfx_index, field_var::ey)
-        //w3 = pfzx->ey;
-        #define w3 k_field(pfzx_index, field_var::ey)
-
-        pi_ey       = fourth*( (w3 + w0) + (w1 + w2) );
-        pi_deydz    = fourth*( (w3 - w0) + (w1 - w2) );
-        pi_deydx    = fourth*( (w3 - w0) - (w1 - w2) );
-        pi_d2eydzdx = fourth*( (w3 + w0) - (w1 + w2) );
-
-        #undef w0
-        #undef w1
-        #undef w2
-        #undef w3
-
-        // ez interpolation coefficients
-
-        // w0 = pf0->ez;
-        #define w0 k_field(pf0_index, field_var::ez)
-        // w1 = pfx->ez;
-        #define w1 k_field(pfx_index, field_var::ez)
-        // w2 = pfy->ez;
-        #define w2 k_field(pfy_index, field_var::ez)
-        // w3 = pfxy->ez;
-        #define w3 k_field(pfxy_index, field_var::ez)
-        pi_ez       = fourth*( (w3 + w0) + (w1 + w2) );
-        pi_dezdx    = fourth*( (w3 - w0) + (w1 - w2) );
-        pi_dezdy    = fourth*( (w3 - w0) - (w1 - w2) );
-        pi_d2ezdxdy = fourth*( (w3 + w0) - (w1 + w2) );
-
-        #undef w0
-        #undef w1
-        #undef w2
-        #undef w3
-
-        // bx interpolation coefficients
-
-        //w0 = pf0->cbx;
-        #define w0 k_field(pf0_index, field_var::cbx)
-        //w1 = pfx->cbx;
-        #define w1 k_field(pfx_index, field_var::cbx)
-        pi_cbx    = half*( w1 + w0 );
-        pi_dcbxdx = half*( w1 - w0 );
-
-        #undef w0
-        #undef w1
-
-        // by interpolation coefficients
-
-        // w0 = pf0->cby;
-        #define w0 k_field(pf0_index, field_var::cby)
-        // w1 = pfy->cby;
-        #define w1 k_field(pfy_index, field_var::cby)
-
-        pi_cby    = half*( w1 + w0 );
-        pi_dcbydy = half*( w1 - w0 );
-
-        #undef w0
-        #undef w1
-
-        // bz interpolation coefficients
-
-        // w0 = pf0->cbz;
-        #define w0 k_field(pf0_index, field_var::cbz)
-        // w1 = pfz->cbz;
-        #define w1 k_field(pfz_index, field_var::cbz)
-        pi_cbz    = half*( w1 + w0 );
-        pi_dcbzdz = half*( w1 - w0 );
-
-        #undef w0
-        #undef w1
-
-        //pi++; pf0++; pfx++; pfy++; pfz++; pfyz++; pfzx++; pfxy++;
-      });
-    }
-    );
-  });
-*/
 }
 
 void
@@ -475,8 +304,7 @@ interpolator_array_t::copy_to_host() {
       host_interp[i].cbx      = k_interpolator_h(i, interpolator_var::cbx);
       host_interp[i].cby      = k_interpolator_h(i, interpolator_var::cby);
       host_interp[i].cbz      = k_interpolator_h(i, interpolator_var::cbz);
-#else
-#ifdef SHAPE_QS
+#elif defined( SHAPE_QS )
       host_interp[i].ex      = k_interpolator_h(i, interpolator_var::ex     );
       host_interp[i].dexdx   = k_interpolator_h(i, interpolator_var::dexdx  );
       host_interp[i].dexdy   = k_interpolator_h(i, interpolator_var::dexdy  );
@@ -520,7 +348,6 @@ interpolator_array_t::copy_to_host() {
       host_interp[i].d2cbzdy = k_interpolator_h(i, interpolator_var::d2cbzdy);
       host_interp[i].d2cbzdz = k_interpolator_h(i, interpolator_var::d2cbzdz);
 #endif
-#endif
     });
 
 }
@@ -542,8 +369,7 @@ interpolator_array_t::copy_to_device() {
       k_interpolator_h(i, interpolator_var::cbx)      = host_interp[i].cbx;
       k_interpolator_h(i, interpolator_var::cby)      = host_interp[i].cby;
       k_interpolator_h(i, interpolator_var::cbz)      = host_interp[i].cbz;
-#else
-#ifdef SHAPE_QS
+#elif defined( SHAPE_QS )
       k_interpolator_h(i, interpolator_var::ex      ) = host_interp[i].ex     ;
       k_interpolator_h(i, interpolator_var::dexdx   ) = host_interp[i].dexdx  ;
       k_interpolator_h(i, interpolator_var::dexdy   ) = host_interp[i].dexdy  ;
@@ -586,7 +412,6 @@ interpolator_array_t::copy_to_device() {
       k_interpolator_h(i, interpolator_var::d2cbzdx ) = host_interp[i].d2cbzdx;
       k_interpolator_h(i, interpolator_var::d2cbzdy ) = host_interp[i].d2cbzdy;
       k_interpolator_h(i, interpolator_var::d2cbzdz ) = host_interp[i].d2cbzdz;
-#endif
 #endif
     });
 

--- a/src/sf_interface/interpolator_array.cc
+++ b/src/sf_interface/interpolator_array.cc
@@ -45,171 +45,255 @@ delete_interpolator_array( interpolator_array_t * ia ) {
 void load_interpolator_array_kokkos(k_interpolator_t k_interp, k_field_t k_field, int nx, int ny, int nz) {
 
   #define pi_ex       k_interp(pi_index, interpolator_var::ex)
+  #define pi_dexdx    k_interp(pi_index, interpolator_var::dexdx)
   #define pi_dexdy    k_interp(pi_index, interpolator_var::dexdy)
   #define pi_dexdz    k_interp(pi_index, interpolator_var::dexdz)
-  #define pi_d2exdydz k_interp(pi_index, interpolator_var::d2exdydz)
-
+  #define pi_d2exdx   k_interp(pi_index, interpolator_var::d2exdx)
+  #define pi_d2exdy   k_interp(pi_index, interpolator_var::d2exdy)
+  #define pi_d2exdz   k_interp(pi_index, interpolator_var::d2exdz)
   #define pi_ey       k_interp(pi_index, interpolator_var::ey)
-  #define pi_deydz    k_interp(pi_index, interpolator_var::deydz)
   #define pi_deydx    k_interp(pi_index, interpolator_var::deydx)
-  #define pi_d2eydzdx k_interp(pi_index, interpolator_var::d2eydzdx)
-
+  #define pi_deydy    k_interp(pi_index, interpolator_var::deydy)
+  #define pi_deydz    k_interp(pi_index, interpolator_var::deydz)
+  #define pi_d2eydx   k_interp(pi_index, interpolator_var::d2eydx)
+  #define pi_d2eydy   k_interp(pi_index, interpolator_var::d2eydy)
+  #define pi_d2eydz   k_interp(pi_index, interpolator_var::d2eydz)
   #define pi_ez       k_interp(pi_index, interpolator_var::ez)
   #define pi_dezdx    k_interp(pi_index, interpolator_var::dezdx)
   #define pi_dezdy    k_interp(pi_index, interpolator_var::dezdy)
-  #define pi_d2ezdxdy k_interp(pi_index, interpolator_var::d2ezdxdy)
-
+  #define pi_dezdz    k_interp(pi_index, interpolator_var::dezdz)
+  #define pi_d2ezdx   k_interp(pi_index, interpolator_var::d2ezdx)
+  #define pi_d2ezdy   k_interp(pi_index, interpolator_var::d2ezdy)
+  #define pi_d2ezdz   k_interp(pi_index, interpolator_var::d2ezdz)
   #define pi_cbx      k_interp(pi_index, interpolator_var::cbx)
   #define pi_dcbxdx   k_interp(pi_index, interpolator_var::dcbxdx)
-
+  #define pi_dcbxdy   k_interp(pi_index, interpolator_var::dcbxdy)
+  #define pi_dcbxdz   k_interp(pi_index, interpolator_var::dcbxdz)
+  #define pi_d2cbxdx  k_interp(pi_index, interpolator_var::d2cbxdx)
+  #define pi_d2cbxdy  k_interp(pi_index, interpolator_var::d2cbxdy)
+  #define pi_d2cbxdz  k_interp(pi_index, interpolator_var::d2cbxdz)
   #define pi_cby      k_interp(pi_index, interpolator_var::cby)
+  #define pi_dcbydx   k_interp(pi_index, interpolator_var::dcbydx)
   #define pi_dcbydy   k_interp(pi_index, interpolator_var::dcbydy)
-
+  #define pi_dcbydz   k_interp(pi_index, interpolator_var::dcbydz)
+  #define pi_d2cbydx  k_interp(pi_index, interpolator_var::d2cbydx)
+  #define pi_d2cbydy  k_interp(pi_index, interpolator_var::d2cbydy)
+  #define pi_d2cbydz  k_interp(pi_index, interpolator_var::d2cbydz)
   #define pi_cbz      k_interp(pi_index, interpolator_var::cbz)
+  #define pi_dcbzdx   k_interp(pi_index, interpolator_var::dcbzdx)
+  #define pi_dcbzdy   k_interp(pi_index, interpolator_var::dcbzdy)
   #define pi_dcbzdz   k_interp(pi_index, interpolator_var::dcbzdz)
+  #define pi_d2cbzdx  k_interp(pi_index, interpolator_var::d2cbzdx)
+  #define pi_d2cbzdy  k_interp(pi_index, interpolator_var::d2cbzdy)
+  #define pi_d2cbzdz  k_interp(pi_index, interpolator_var::d2cbzdz)
 
-  const float fourth = 0.25;
-  const float half   = 0.5;
+  const float twelfth = 1./12.;
+  const float sixth   = 1./6.;
+  const float half    = 0.5;
+  const float two     = 2.0;
+  const float six     = 6.;
 
     Kokkos::MDRangePolicy<Kokkos::Rank<3>> load_policy({1, 1, 1}, {nz+1, ny+1, nx+1});
     Kokkos::parallel_for("load interpolator", load_policy, KOKKOS_LAMBDA(const int z, const int y, const int x) {
-        //pi = &fi(1,y,z);
-        int pi_index = VOXEL(1,   y,   z, nx,ny,nz) + x-1;
-
-        //pf0 = &f(1,y,z);
-        int pf0_index = VOXEL(1,  y,   z, nx,ny,nz) + x-1;
-
-        //pfx = &f(2,y,z);
-        int pfx_index = VOXEL(2,  y,   z, nx,ny,nz) + x-1;
-
-        //pfy = &f(1,y+1,z);
-        int pfy_index = VOXEL(1,  y+1, z, nx,ny,nz) + x-1;
-
-        //pfz = &f(1,y,z+1);
-        int pfz_index = VOXEL(1,  y,   z+1, nx,ny,nz) + x-1;
-
-        //pfyz = &f(1,y+1,z+1);
-        int pfyz_index = VOXEL(1, y+1, z+1, nx,ny,nz) + x-1;
-
-        //pfzx = &f(2,y,z+1);
-        int pfzx_index = VOXEL(2, y,   z+1, nx,ny,nz) + x-1;
-
-        //pfxy = &f(2,y+1,z);
-        int pfxy_index = VOXEL(2, y+1, z, nx,ny,nz) + x-1;
+        int pi_index = VOXEL(1,   y,   z, nx,ny,nz) + x-1; //pi = &fi(1,y,z);
+        int pf0_index = VOXEL(1,  y,   z, nx,ny,nz) + x-1; //pf0 = &f(1,y,z);
+        int pfx_index = VOXEL(2,  y,   z, nx,ny,nz) + x-1; //pfx = &f(2,y,z);
+        int pfy_index = VOXEL(1,  y+1, z, nx,ny,nz) + x-1; //pfy = &f(1,y+1,z);
+        int pfz_index = VOXEL(1,  y,   z+1, nx,ny,nz) + x-1; //pfz = &f(1,y,z+1);
+        int pfmx_index = VOXEL(x-1, y,   z,   nx,ny,nz);
+        int pfmy_index = VOXEL(x,   y-1, z,   nx,ny,nz);
+        int pfmz_index = VOXEL(x,   y,   z-1, nx,ny,nz);
 
         // ex interpolation coefficients
         // ex->tx from hyb_smooth_eb(...)
-        //w0 = pf0->ex;
-        #define w0 k_field(pf0_index, field_var::tx)
-        //w1 = pfy->ex;
-        #define w1 k_field(pfy_index, field_var::tx)
-        //w2 = pfz->ex;
-        #define w2 k_field(pfz_index, field_var::tx)
-        //w3 = pfyz->ex;
-        #define w3 k_field(pfyz_index, field_var::tx)
+        auto w0  = k_field(pf0_index,  field_var::tx);
+        auto wx  = k_field(pfx_index,  field_var::tx);
+        auto wy  = k_field(pfy_index,  field_var::tx);
+        auto wz  = k_field(pfz_index,  field_var::tx);
+        auto wmx = k_field(pfmx_index, field_var::tx);
+        auto wmy = k_field(pfmy_index, field_var::tx);
+        auto wmz = k_field(pfmz_index, field_var::tx);
 
-        pi_ex       = w0;//fourth*( (w3 + w0) + (w1 + w2) );
-        pi_dexdy    = fourth*( (w3 - w0) + (w1 - w2) );
-        pi_dexdz    = fourth*( (w3 - w0) - (w1 - w2) );
-        pi_d2exdydz = fourth*( (w3 + w0) - (w1 + w2) );
-
-        #undef w0
-        #undef w1
-        #undef w2
-        #undef w3
+#ifdef SHAPE_NGP
+        pi_ex     = w0;
+#else
+#ifdef SHAPE_QS
+        pi_ex     = twelfth*(six*w0 + wx + wy + wz + wmx + wmy + wmz);
+        pi_dexdx  = sixth*(wx - wmx);
+        pi_dexdy  = sixth*(wy - wmy);
+        pi_dexdz  = sixth*(wz - wmz);
+        pi_d2exdx = twelfth*(wx + wmx - two*w0);
+        pi_d2exdy = twelfth*(wy + wmy - two*w0);
+        pi_d2exdz = twelfth*(wz + wmz - two*w0);
+#endif
+#endif
 
         // ey interpolation coefficients
         // ey->ty from hyb_smooth_eb(...)
+        w0  = k_field(pf0_index,  field_var::ty);
+        wx  = k_field(pfx_index,  field_var::ty);
+        wy  = k_field(pfy_index,  field_var::ty);
+        wz  = k_field(pfz_index,  field_var::ty);
+        wmx = k_field(pfmx_index, field_var::ty);
+        wmy = k_field(pfmy_index, field_var::ty);
+        wmz = k_field(pfmz_index, field_var::ty);
 
-        //w0 = pf0->ey;
-        #define w0 k_field(pf0_index, field_var::ty)
-        //w1 = pfz->ey;
-        #define w1 k_field(pfz_index, field_var::ty)
-        //w2 = pfx->ey;
-        #define w2 k_field(pfx_index, field_var::ty)
-        //w3 = pfzx->ey;
-        #define w3 k_field(pfzx_index, field_var::ty)
-
-        pi_ey       = w0;//fourth*( (w3 + w0) + (w1 + w2) );
-        pi_deydz    = fourth*( (w3 - w0) + (w1 - w2) );
-        pi_deydx    = fourth*( (w3 - w0) - (w1 - w2) );
-        pi_d2eydzdx = fourth*( (w3 + w0) - (w1 + w2) );
-
-        #undef w0
-        #undef w1
-        #undef w2
-        #undef w3
+#ifdef SHAPE_NGP
+        pi_ey     = w0;
+#else
+#ifdef SHAPE_QS
+        pi_ey     = twelfth*(six*w0 + wx + wy + wz + wmx + wmy + wmz);
+        pi_deydx  = sixth*(wx - wmx);
+        pi_deydy  = sixth*(wy - wmy);
+        pi_deydz  = sixth*(wz - wmz);
+        pi_d2eydx = twelfth*(wx + wmx - two*w0);
+        pi_d2eydy = twelfth*(wy + wmy - two*w0);
+        pi_d2eydz = twelfth*(wz + wmz - two*w0);
+#endif
+#endif
 
         // ez interpolation coefficients
         // ez->tz from hyb_smooth_eb(...)
+        w0  = k_field(pf0_index,  field_var::tz);
+        wx  = k_field(pfx_index,  field_var::tz);
+        wy  = k_field(pfy_index,  field_var::tz);
+        wz  = k_field(pfz_index,  field_var::tz);
+        wmx = k_field(pfmx_index, field_var::tz);
+        wmy = k_field(pfmy_index, field_var::tz);
+        wmz = k_field(pfmz_index, field_var::tz);
 
-        // w0 = pf0->ez;
-        #define w0 k_field(pf0_index, field_var::tz)
-        // w1 = pfx->ez;
-        #define w1 k_field(pfx_index, field_var::tz)
-        // w2 = pfy->ez;
-        #define w2 k_field(pfy_index, field_var::tz)
-        // w3 = pfxy->ez;
-        #define w3 k_field(pfxy_index, field_var::tz)
-        pi_ez       = w0;//fourth*( (w3 + w0) + (w1 + w2) );
-        pi_dezdx    = fourth*( (w3 - w0) + (w1 - w2) );
-        pi_dezdy    = fourth*( (w3 - w0) - (w1 - w2) );
-        pi_d2ezdxdy = fourth*( (w3 + w0) - (w1 + w2) );
-
-        #undef w0
-        #undef w1
-        #undef w2
-        #undef w3
+#ifdef SHAPE_NGP
+        pi_ez     = w0;
+#else
+#ifdef SHAPE_QS
+        pi_ez     = twelfth*(six*w0 + wx + wy + wz + wmx + wmy + wmz);
+        pi_dezdx  = sixth*(wx - wmx);
+        pi_dezdy  = sixth*(wy - wmy);
+        pi_dezdz  = sixth*(wz - wmz);
+        pi_d2ezdx = twelfth*(wx + wmx - two*w0);
+        pi_d2ezdy = twelfth*(wy + wmy - two*w0);
+        pi_d2ezdz = twelfth*(wz + wmz - two*w0);
+#endif
+#endif
 
         // bx interpolation coefficients
         // cbx->ox from hyb_smooth_eb(...)
+        w0  = k_field(pf0_index,  field_var::ox) + k_field(pf0_index,  field_var::cbx0);
+        wx  = k_field(pfx_index,  field_var::ox) + k_field(pfx_index,  field_var::cbx0);
+        wy  = k_field(pfy_index,  field_var::ox) + k_field(pfy_index,  field_var::cbx0);
+        wz  = k_field(pfz_index,  field_var::ox) + k_field(pfz_index,  field_var::cbx0);
+        wmx = k_field(pfmx_index, field_var::ox) + k_field(pfmx_index, field_var::cbx0);
+        wmy = k_field(pfmy_index, field_var::ox) + k_field(pfmy_index, field_var::cbx0);
+        wmz = k_field(pfmz_index, field_var::ox) + k_field(pfmz_index, field_var::cbx0);
 
-        //w0 = pf0->cbx;
-        #define w0 k_field(pf0_index, field_var::ox)
-	#define w0b k_field(pf0_index, field_var::cbx0)
-        //w1 = pfx->cbx;
-        #define w1 k_field(pfx_index, field_var::ox)
-	//	#define w1b k_field(pfx_index, field_var::cbx0)
-        pi_cbx    = w0 + w0b;//half*( w1 + w0 );
-        pi_dcbxdx = half*( w1 - w0 ); // To-do: Fix for QS
-
-        #undef w0
-	#undef w0b
-        #undef w1
+#ifdef SHAPE_NGP
+        pi_cbx     = w0;
+#else
+#ifdef SHAPE_QS
+        pi_cbx     = twelfth*(six*w0 + wx + wy + wz + wmx + wmy + wmz);
+        pi_dcbxdx  = sixth*(wx - wmx);
+        pi_dcbxdy  = sixth*(wy - wmy);
+        pi_dcbxdz  = sixth*(wz - wmz);
+        pi_d2cbxdx = twelfth*(wx + wmx - two*w0);
+        pi_d2cbxdy = twelfth*(wy + wmy - two*w0);
+        pi_d2cbxdz = twelfth*(wz + wmz - two*w0);
+#endif
+#endif
 
         // by interpolation coefficients
         // cby->oy from hyb_smooth_eb(...)
+        w0  = k_field(pf0_index,  field_var::oy) + k_field(pf0_index,  field_var::cby0);
+        wx  = k_field(pfx_index,  field_var::oy) + k_field(pfx_index,  field_var::cby0);
+        wy  = k_field(pfy_index,  field_var::oy) + k_field(pfy_index,  field_var::cby0);
+        wz  = k_field(pfz_index,  field_var::oy) + k_field(pfz_index,  field_var::cby0);
+        wmx = k_field(pfmx_index, field_var::oy) + k_field(pfmx_index, field_var::cby0);
+        wmy = k_field(pfmy_index, field_var::oy) + k_field(pfmy_index, field_var::cby0);
+        wmz = k_field(pfmz_index, field_var::oy) + k_field(pfmz_index, field_var::cby0);
 
-        // w0 = pf0->cby;
-        #define w0 k_field(pf0_index, field_var::oy)
-	#define w0b k_field(pf0_index, field_var::cby0)
-        // w1 = pfy->cby;
-        #define w1 k_field(pfy_index, field_var::oy)
-
-        pi_cby    = w0 + w0b;//half*( w1 + w0 );
-        pi_dcbydy = half*( w1 - w0 ); // To-do: Fix for QS
-
-        #undef w0
-	#undef w0b
-        #undef w1
+#ifdef SHAPE_NGP
+        pi_cby     = w0;
+#else
+#ifdef SHAPE_QS
+        pi_cby     = twelfth*(six*w0 + wx + wy + wz + wmx + wmy + wmz);
+        pi_dcbydx  = sixth*(wx - wmx);
+        pi_dcbydy  = sixth*(wy - wmy);
+        pi_dcbydz  = sixth*(wz - wmz);
+        pi_d2cbydx = twelfth*(wx + wmx - two*w0);
+        pi_d2cbydy = twelfth*(wy + wmy - two*w0);
+        pi_d2cbydz = twelfth*(wz + wmz - two*w0);
+#endif
+#endif
 
         // bz interpolation coefficients
         // cbz->oz from hyb_smooth_eb(...)
+        w0  = k_field(pf0_index,  field_var::oz) + k_field(pf0_index,  field_var::cbz0);
+        wx  = k_field(pfx_index,  field_var::oz) + k_field(pfx_index,  field_var::cbz0);
+        wy  = k_field(pfy_index,  field_var::oz) + k_field(pfy_index,  field_var::cbz0);
+        wz  = k_field(pfz_index,  field_var::oz) + k_field(pfz_index,  field_var::cbz0);
+        wmx = k_field(pfmx_index, field_var::oz) + k_field(pfmx_index, field_var::cbz0);
+        wmy = k_field(pfmy_index, field_var::oz) + k_field(pfmy_index, field_var::cbz0);
+        wmz = k_field(pfmz_index, field_var::oz) + k_field(pfmz_index, field_var::cbz0);
 
-        // w0 = pf0->cbz;
-        #define w0 k_field(pf0_index, field_var::oz)
-	#define w0b k_field(pf0_index, field_var::cbz0)
-        // w1 = pfz->cbz;
-        #define w1 k_field(pfz_index, field_var::oz)
-        pi_cbz    = w0 + w0b;//half*( w1 + w0 );
-        pi_dcbzdz = half*( w1 - w0 ); // To-do: Fix for QS
-
-        #undef w0
-	#undef w0b
-        #undef w1
+#ifdef SHAPE_NGP
+        pi_cbz     = w0;
+#else
+#ifdef SHAPE_QS
+        pi_cbz     = twelfth*(six*w0 + wx + wy + wz + wmx + wmy + wmz);
+        pi_dcbzdx  = sixth*(wx - wmx);
+        pi_dcbzdy  = sixth*(wy - wmy);
+        pi_dcbzdz  = sixth*(wz - wmz);
+        pi_d2cbzdx = twelfth*(wx + wmx - two*w0);
+        pi_d2cbzdy = twelfth*(wy + wmy - two*w0);
+        pi_d2cbzdz = twelfth*(wz + wmz - two*w0);
+#endif
+#endif
 
         //pi++; pf0++; pfx++; pfy++; pfz++; pfyz++; pfzx++; pfxy++;
-    });
+
+    }); // end Kokkos::parallel_for("load interpolator")
+
+  #undef pi_ex
+  #undef pi_dexdx
+  #undef pi_dexdy
+  #undef pi_dexdz
+  #undef pi_d2exdx
+  #undef pi_d2exdy
+  #undef pi_d2exdz
+  #undef pi_ey
+  #undef pi_deydx
+  #undef pi_deydy
+  #undef pi_deydz
+  #undef pi_d2eydx
+  #undef pi_d2eydy
+  #undef pi_d2eydz
+  #undef pi_ez
+  #undef pi_dezdx
+  #undef pi_dezdy
+  #undef pi_dezdz
+  #undef pi_d2ezdx
+  #undef pi_d2ezdy
+  #undef pi_d2ezdz
+  #undef pi_cbx
+  #undef pi_dcbxdx
+  #undef pi_dcbxdy
+  #undef pi_dcbxdz
+  #undef pi_d2cbxdx
+  #undef pi_d2cbxdy
+  #undef pi_d2cbxdz
+  #undef pi_cby
+  #undef pi_dcbydx
+  #undef pi_dcbydy
+  #undef pi_dcbydz
+  #undef pi_d2cbydx
+  #undef pi_d2cbydy
+  #undef pi_d2cbydz
+  #undef pi_cbz
+  #undef pi_dcbzdx
+  #undef pi_dcbzdy
+  #undef pi_dcbzdz
+  #undef pi_d2cbzdx
+  #undef pi_d2cbzdy
+  #undef pi_d2cbzdz
 
 /*
     Kokkos::parallel_for("load interpolator", KOKKOS_TEAM_POLICY_DEVICE
@@ -384,6 +468,7 @@ interpolator_array_t::copy_to_host() {
   Kokkos::parallel_for("Copy interpolators to host",
     host_execution_policy(0, g->nv) ,
     KOKKOS_LAMBDA (int i) {
+#ifdef SHAPE_NGP
       host_interp[i].ex       = k_interpolator_h(i, interpolator_var::ex);
       host_interp[i].ey       = k_interpolator_h(i, interpolator_var::ey);
       host_interp[i].ez       = k_interpolator_h(i, interpolator_var::ez);
@@ -402,6 +487,52 @@ interpolator_array_t::copy_to_host() {
       host_interp[i].dcbxdx   = k_interpolator_h(i, interpolator_var::dcbxdx);
       host_interp[i].dcbydy   = k_interpolator_h(i, interpolator_var::dcbydy);
       host_interp[i].dcbzdz   = k_interpolator_h(i, interpolator_var::dcbzdz);
+#else
+#ifdef SHAPE_QS
+      host_interp[i].ex      = k_interpolator_h(i, interpolator_var::ex     );
+      host_interp[i].dexdx   = k_interpolator_h(i, interpolator_var::dexdx  );
+      host_interp[i].dexdy   = k_interpolator_h(i, interpolator_var::dexdy  );
+      host_interp[i].dexdz   = k_interpolator_h(i, interpolator_var::dexdz  );
+      host_interp[i].d2exdx  = k_interpolator_h(i, interpolator_var::d2exdx );
+      host_interp[i].d2exdy  = k_interpolator_h(i, interpolator_var::d2exdy );
+      host_interp[i].d2exdz  = k_interpolator_h(i, interpolator_var::d2exdz );
+      host_interp[i].ey      = k_interpolator_h(i, interpolator_var::ey     );
+      host_interp[i].deydx   = k_interpolator_h(i, interpolator_var::deydx  );
+      host_interp[i].deydy   = k_interpolator_h(i, interpolator_var::deydy  );
+      host_interp[i].deydz   = k_interpolator_h(i, interpolator_var::deydz  );
+      host_interp[i].d2eydx  = k_interpolator_h(i, interpolator_var::d2eydx );
+      host_interp[i].d2eydy  = k_interpolator_h(i, interpolator_var::d2eydy );
+      host_interp[i].d2eydz  = k_interpolator_h(i, interpolator_var::d2eydz );
+      host_interp[i].ez      = k_interpolator_h(i, interpolator_var::ez     );
+      host_interp[i].dezdx   = k_interpolator_h(i, interpolator_var::dezdx  );
+      host_interp[i].dezdy   = k_interpolator_h(i, interpolator_var::dezdy  );
+      host_interp[i].dezdz   = k_interpolator_h(i, interpolator_var::dezdz  );
+      host_interp[i].d2ezdx  = k_interpolator_h(i, interpolator_var::d2ezdx );
+      host_interp[i].d2ezdy  = k_interpolator_h(i, interpolator_var::d2ezdy );
+      host_interp[i].d2ezdz  = k_interpolator_h(i, interpolator_var::d2ezdz );
+      host_interp[i].cbx     = k_interpolator_h(i, interpolator_var::cbx    );
+      host_interp[i].dcbxdx  = k_interpolator_h(i, interpolator_var::dcbxdx );
+      host_interp[i].dcbxdy  = k_interpolator_h(i, interpolator_var::dcbxdy );
+      host_interp[i].dcbxdz  = k_interpolator_h(i, interpolator_var::dcbxdz );
+      host_interp[i].d2cbxdx = k_interpolator_h(i, interpolator_var::d2cbxdx);
+      host_interp[i].d2cbxdy = k_interpolator_h(i, interpolator_var::d2cbxdy);
+      host_interp[i].d2cbxdz = k_interpolator_h(i, interpolator_var::d2cbxdz);
+      host_interp[i].cby     = k_interpolator_h(i, interpolator_var::cby    );
+      host_interp[i].dcbydx  = k_interpolator_h(i, interpolator_var::dcbydx );
+      host_interp[i].dcbydy  = k_interpolator_h(i, interpolator_var::dcbydy );
+      host_interp[i].dcbydz  = k_interpolator_h(i, interpolator_var::dcbydz );
+      host_interp[i].d2cbydx = k_interpolator_h(i, interpolator_var::d2cbydx);
+      host_interp[i].d2cbydy = k_interpolator_h(i, interpolator_var::d2cbydy);
+      host_interp[i].d2cbydz = k_interpolator_h(i, interpolator_var::d2cbydz);
+      host_interp[i].cbz     = k_interpolator_h(i, interpolator_var::cbz    );
+      host_interp[i].dcbzdx  = k_interpolator_h(i, interpolator_var::dcbzdx );
+      host_interp[i].dcbzdy  = k_interpolator_h(i, interpolator_var::dcbzdy );
+      host_interp[i].dcbzdz  = k_interpolator_h(i, interpolator_var::dcbzdz );
+      host_interp[i].d2cbzdx = k_interpolator_h(i, interpolator_var::d2cbzdx);
+      host_interp[i].d2cbzdy = k_interpolator_h(i, interpolator_var::d2cbzdy);
+      host_interp[i].d2cbzdz = k_interpolator_h(i, interpolator_var::d2cbzdz);
+#endif
+#endif
     });
 
 }
@@ -416,6 +547,7 @@ interpolator_array_t::copy_to_device() {
   Kokkos::parallel_for("Copy interpolators to device",
     host_execution_policy(0, g->nv) ,
     KOKKOS_LAMBDA (int i) {
+#ifdef SHAPE_NGP
       k_interpolator_h(i, interpolator_var::ex)       = host_interp[i].ex;
       k_interpolator_h(i, interpolator_var::ey)       = host_interp[i].ey;
       k_interpolator_h(i, interpolator_var::ez)       = host_interp[i].ez;
@@ -434,6 +566,52 @@ interpolator_array_t::copy_to_device() {
       k_interpolator_h(i, interpolator_var::dcbxdx)   = host_interp[i].dcbxdx;
       k_interpolator_h(i, interpolator_var::dcbydy)   = host_interp[i].dcbydy;
       k_interpolator_h(i, interpolator_var::dcbzdz)   = host_interp[i].dcbzdz;
+#else
+#ifdef SHAPE_QS
+      k_interpolator_h(i, interpolator_var::ex      ) = host_interp[i].ex     ;
+      k_interpolator_h(i, interpolator_var::dexdx   ) = host_interp[i].dexdx  ;
+      k_interpolator_h(i, interpolator_var::dexdy   ) = host_interp[i].dexdy  ;
+      k_interpolator_h(i, interpolator_var::dexdz   ) = host_interp[i].dexdz  ;
+      k_interpolator_h(i, interpolator_var::d2exdx  ) = host_interp[i].d2exdx ;
+      k_interpolator_h(i, interpolator_var::d2exdy  ) = host_interp[i].d2exdy ;
+      k_interpolator_h(i, interpolator_var::d2exdz  ) = host_interp[i].d2exdz ;
+      k_interpolator_h(i, interpolator_var::ey      ) = host_interp[i].ey     ;
+      k_interpolator_h(i, interpolator_var::deydx   ) = host_interp[i].deydx  ;
+      k_interpolator_h(i, interpolator_var::deydy   ) = host_interp[i].deydy  ;
+      k_interpolator_h(i, interpolator_var::deydz   ) = host_interp[i].deydz  ;
+      k_interpolator_h(i, interpolator_var::d2eydx  ) = host_interp[i].d2eydx ;
+      k_interpolator_h(i, interpolator_var::d2eydy  ) = host_interp[i].d2eydy ;
+      k_interpolator_h(i, interpolator_var::d2eydz  ) = host_interp[i].d2eydz ;
+      k_interpolator_h(i, interpolator_var::ez      ) = host_interp[i].ez     ;
+      k_interpolator_h(i, interpolator_var::dezdx   ) = host_interp[i].dezdx  ;
+      k_interpolator_h(i, interpolator_var::dezdy   ) = host_interp[i].dezdy  ;
+      k_interpolator_h(i, interpolator_var::dezdz   ) = host_interp[i].dezdz  ;
+      k_interpolator_h(i, interpolator_var::d2ezdx  ) = host_interp[i].d2ezdx ;
+      k_interpolator_h(i, interpolator_var::d2ezdy  ) = host_interp[i].d2ezdy ;
+      k_interpolator_h(i, interpolator_var::d2ezdz  ) = host_interp[i].d2ezdz ;
+      k_interpolator_h(i, interpolator_var::cbx     ) = host_interp[i].cbx    ;
+      k_interpolator_h(i, interpolator_var::dcbxdx  ) = host_interp[i].dcbxdx ;
+      k_interpolator_h(i, interpolator_var::dcbxdy  ) = host_interp[i].dcbxdy ;
+      k_interpolator_h(i, interpolator_var::dcbxdz  ) = host_interp[i].dcbxdz ;
+      k_interpolator_h(i, interpolator_var::d2cbxdx ) = host_interp[i].d2cbxdx;
+      k_interpolator_h(i, interpolator_var::d2cbxdy ) = host_interp[i].d2cbxdy;
+      k_interpolator_h(i, interpolator_var::d2cbxdz ) = host_interp[i].d2cbxdz;
+      k_interpolator_h(i, interpolator_var::cby     ) = host_interp[i].cby    ;
+      k_interpolator_h(i, interpolator_var::dcbydx  ) = host_interp[i].dcbydx ;
+      k_interpolator_h(i, interpolator_var::dcbydy  ) = host_interp[i].dcbydy ;
+      k_interpolator_h(i, interpolator_var::dcbydz  ) = host_interp[i].dcbydz ;
+      k_interpolator_h(i, interpolator_var::d2cbydx ) = host_interp[i].d2cbydx;
+      k_interpolator_h(i, interpolator_var::d2cbydy ) = host_interp[i].d2cbydy;
+      k_interpolator_h(i, interpolator_var::d2cbydz ) = host_interp[i].d2cbydz;
+      k_interpolator_h(i, interpolator_var::cbz     ) = host_interp[i].cbz    ;
+      k_interpolator_h(i, interpolator_var::dcbzdx  ) = host_interp[i].dcbzdx ;
+      k_interpolator_h(i, interpolator_var::dcbzdy  ) = host_interp[i].dcbzdy ;
+      k_interpolator_h(i, interpolator_var::dcbzdz  ) = host_interp[i].dcbzdz ;
+      k_interpolator_h(i, interpolator_var::d2cbzdx ) = host_interp[i].d2cbzdx;
+      k_interpolator_h(i, interpolator_var::d2cbzdy ) = host_interp[i].d2cbzdy;
+      k_interpolator_h(i, interpolator_var::d2cbzdz ) = host_interp[i].d2cbzdz;
+#endif
+#endif
     });
 
   Kokkos::deep_copy(k_i_d, k_i_h);

--- a/src/sf_interface/sf_interface.h
+++ b/src/sf_interface/sf_interface.h
@@ -21,6 +21,8 @@
 // fi(0,:,:) or fi(nx+1,:,:)) are not used.
 
 typedef struct interpolator {
+#ifdef SHAPE_NGP
+  // TODO trim memory usage, only 6 floats + 2 pad needed!! --ATr,2024nov08
   float ex, dexdy, dexdz, d2exdydz;
   float ey, deydz, deydx, d2eydzdx;
   float ez, dezdx, dezdy, d2ezdxdy;
@@ -28,6 +30,20 @@ typedef struct interpolator {
   float cby, dcbydy;
   float cbz, dcbzdz;
   float _pad[2];  // 16-byte align
+#else
+#ifdef SHAPE_QS
+  // TODO(low-priority) TEST LAYOUT - is it better to interleave padding so ex,ey,ez;bx,by,bz
+  // are cleanly spaced on 32-byte boundaries, or only pad end of struct????
+  // --ATr,2024nov08
+  float ex,   dexdx,  dexdy,  dexdz,  d2exdx,  d2exdy,  d2exdz;
+  float ey,   deydx,  deydy,  deydz,  d2eydx,  d2eydy,  d2eydz;
+  float ez,   dezdx,  dezdy,  dezdz,  d2ezdx,  d2ezdy,  d2ezdz;
+  float cbx, dcbxdx, dcbxdy, dcbxdz, d2cbxdx, d2cbxdy, d2cbxdz;
+  float cby, dcbydx, dcbydy, dcbydz, d2cbydx, d2cbydy, d2cbydz;
+  float cbz, dcbzdx, dcbzdy, dcbzdz, d2cbzdx, d2cbzdy, d2cbzdz;
+  float _pad[2]; // 16-byte align
+#endif
+#endif
 } interpolator_t;
 
 typedef struct interpolator_array {

--- a/src/sf_interface/sf_interface.h
+++ b/src/sf_interface/sf_interface.h
@@ -22,13 +22,14 @@
 
 typedef struct interpolator {
 #ifdef SHAPE_NGP
-  // TODO trim memory usage, only 6 floats + 2 pad needed!! --ATr,2024nov08
-  float ex, dexdy, dexdz, d2exdydz;
-  float ey, deydz, deydx, d2eydzdx;
-  float ez, dezdx, dezdy, d2ezdxdy;
-  float cbx, dcbxdx;
-  float cby, dcbydy;
-  float cbz, dcbzdz;
+  //float ex, dexdy, dexdz, d2exdydz;
+  //float ey, deydz, deydx, d2eydzdx;
+  //float ez, dezdx, dezdy, d2ezdxdy;
+  //float cbx, dcbxdx;
+  //float cby, dcbydy;
+  //float cbz, dcbzdz;
+  float ex, ey, ez;
+  float cbx, cby, cbz;
   float _pad[2];  // 16-byte align
 #else
 #ifdef SHAPE_QS

--- a/src/species_advance/species_advance.h
+++ b/src/species_advance/species_advance.h
@@ -467,7 +467,7 @@ move_p_kokkos(
   //int pi = int(local_pm_i);
   int pi = pm->i;
   float ux,uy,uz,u,absdisp,x_half,y_half,z_half,fracdt;
-  const float one=1., two=2., three=3., one_twelfth=1./12.;
+  constexpr float one=1., two=2., three=3., one_twelfth=1./12.;
   //const float gdx=g->dx, gdy=g->dy, gdz=g->dz, gdt=g->dt;
   const float rV = 1.0/gdx/gdy/gdz;
   const float rV12 = rV*one_twelfth;
@@ -534,25 +534,24 @@ move_p_kokkos(
 	//if (std::is_same<scatter_view_t,k_field_sa_t>::value) {
 	  
 #ifdef SHAPE_NGP
-	  scatter_access(ii, field_var::jfx) += q*rV*ux;
-	  scatter_access(ii, field_var::jfy) += q*rV*uy;
-	  scatter_access(ii, field_var::jfz) += q*rV*uz;
-	  scatter_access(ii, field_var::rhof) += q*rV;
-#else
-#ifdef SHAPE_QS
+          scatter_access(ii, field_var::jfx) += q*rV*ux;
+          scatter_access(ii, field_var::jfy) += q*rV*uy;
+          scatter_access(ii, field_var::jfz) += q*rV*uz;
+          scatter_access(ii, field_var::rhof) += q*rV;
+#elif defined( SHAPE_QS )
           // stencil coefficients
           // ... OLD hybrid-VPIC with QS shape, the accumulator stores
           // ... ... p->w*qsp * two*(three - ...)
           // ... ... hyb_unload_accumulator(...) applies factor rV/12.
           // ... NEW HVPIC-K not using accumulator (yet), scatter directly to mesh,
           // ... ... so include all factors
-          w0 =  q*rV12*two*( three - x_half*x_half - y_half*y_half - z_half*z_half );
-          wx =  q*rV12*( x_half + one )*( x_half + one );
-          wy =  q*rV12*( y_half + one )*( y_half + one );
-          wz =  q*rV12*( z_half + one )*( z_half + one );
-          wmx = q*rV12*( x_half - one )*( x_half - one );
-          wmy = q*rV12*( y_half - one )*( y_half - one );
-          wmz = q*rV12*( z_half - one )*( z_half - one );
+          w0 =  q*rV12*2.f*( 3.f - x_half*x_half - y_half*y_half - z_half*z_half );
+          wx =  q*rV12*( x_half + 1.f )*( x_half + 1.f );
+          wy =  q*rV12*( y_half + 1.f )*( y_half + 1.f );
+          wz =  q*rV12*( z_half + 1.f )*( z_half + 1.f );
+          wmx = q*rV12*( x_half - 1.f )*( x_half - 1.f );
+          wmy = q*rV12*( y_half - 1.f )*( y_half - 1.f );
+          wmz = q*rV12*( z_half - 1.f )*( z_half - 1.f );
 
           // Voxel indices
           int iii = ii;
@@ -603,7 +602,6 @@ move_p_kokkos(
           scatter_access(iimz, field_var::jfz)  += wmz*uz;
           scatter_access(iimz, field_var::rhof) += wmz;
 #endif // defined(SHAPE_QS)
-#endif // defined(SHAPE_NGP)
 	//}
 	
 	
@@ -823,7 +821,7 @@ move_p_kokkos_host_serial(
   const int nz = g->nz;
 
   float ux,uy,uz,u,absdisp,x_half,y_half,z_half,fracdt;
-  const float one=1., two=2., three=3., one_twelfth=1./12.;
+  constexpr float one=1., two=2., three=3., one_twelfth=1./12.;
   const float gdx=g->dx, gdy=g->dy, gdz=g->dz, gdt=g->dt;
   const float rV = g->rdx * g->rdy * g->rdz;
   const float rV12 = rV*one_twelfth;
@@ -916,21 +914,20 @@ move_p_kokkos_host_serial(
         k_jf_accum(ii, accumulator_var::jy) += q*rV*uy;
         k_jf_accum(ii, accumulator_var::jz) += q*rV*uz;
         k_jf_accum(ii, accumulator_var::rho) += q*rV;
-#else
-#ifdef SHAPE_QS
+#elif defined( SHAPE_QS )
         // stencil coefficients
         // ... OLD hybrid-VPIC with QS shape, the accumulator stores
         // ... ... p->w*qsp * two*(three - ...)
         // ... ... hyb_unload_accumulator(...) applies factor rV/12.
         // ... NEW HVPIC-K not using accumulator (yet), scatter directly to mesh,
         // ... ... so include all factors
-        w0 =  q*rV12*two*( three - x_half*x_half - y_half*y_half - z_half*z_half );
-        wx =  q*rV12*( x_half + one )*( x_half + one );
-        wy =  q*rV12*( y_half + one )*( y_half + one );
-        wz =  q*rV12*( z_half + one )*( z_half + one );
-        wmx = q*rV12*( x_half - one )*( x_half - one );
-        wmy = q*rV12*( y_half - one )*( y_half - one );
-        wmz = q*rV12*( z_half - one )*( z_half - one );
+        w0 =  q*rV12*2.f*( 3.f - x_half*x_half - y_half*y_half - z_half*z_half );
+        wx =  q*rV12*( x_half + 1.f )*( x_half + 1.f );
+        wy =  q*rV12*( y_half + 1.f )*( y_half + 1.f );
+        wz =  q*rV12*( z_half + 1.f )*( z_half + 1.f );
+        wmx = q*rV12*( x_half - 1.f )*( x_half - 1.f );
+        wmy = q*rV12*( y_half - 1.f )*( y_half - 1.f );
+        wmz = q*rV12*( z_half - 1.f )*( z_half - 1.f );
 
         // Voxel indices
         int iii = ii;
@@ -981,7 +978,6 @@ move_p_kokkos_host_serial(
         k_jf_accum(iimz, accumulator_var::jz)  += wmz*uz;
         k_jf_accum(iimz, accumulator_var::rho) += wmz;
 #endif // defined(SHAPE_QS)
-#endif // defined(SHAPE_NGP)
 
       } //if indbds
       

--- a/src/species_advance/species_advance.h
+++ b/src/species_advance/species_advance.h
@@ -461,14 +461,16 @@ move_p_kokkos(
   float s_dispx, s_dispy, s_dispz;
   float s_dir[3];
   float v0, v1, v2, v3, v4, v5, q;
+  float w0, wx, wy, wz, wmx, wmy, wmz;
   int axis, face;
   int64_t neighbor;
   //int pi = int(local_pm_i);
   int pi = pm->i;
   float ux,uy,uz,u,absdisp,x_half,y_half,z_half,fracdt;
-  const float one=1., two=2., three=3.;
+  const float one=1., two=2., three=3., one_twelfth=1./12.;
   //const float gdx=g->dx, gdy=g->dy, gdz=g->dz, gdt=g->dt;
   const float rV = 1.0/gdx/gdy/gdz;
+  const float rV12 = rV*one_twelfth;
 //  auto  k_field_scatter_access = k_f_sa.access();
 //  auto accum_sa = accum_sv.access();
   auto scatter_access = scatter_view.access();
@@ -476,10 +478,11 @@ move_p_kokkos(
   //printf("in move_p %d \n", pi);
 
 #ifdef VARIABLE_CHARGE
-  q = rV*p_q*p_w;
+  q = p_q*p_w;
 #else
-  q = rV*qsp*p_w;
+  q = qsp*p_w;
 #endif
+
     //printf("in move %d \n", pi);
 
   for(;;) {
@@ -525,21 +528,82 @@ move_p_kokkos(
         
 	// Accumulate the particle current density
 	
-	//int iii = ii;
-	//int zi = iii/((nx+2)*(ny+2));
-	//iii -= zi*(nx+2)*(ny+2);
-	//int yi = iii/(nx+2);
-	//int xi = iii-yi*(nx+2);
-	
 	//printf("move_p accumulate here");
 	
 	
 	//if (std::is_same<scatter_view_t,k_field_sa_t>::value) {
 	  
-	  scatter_access(ii, field_var::jfx) += q*ux;
-	  scatter_access(ii, field_var::jfy) += q*uy;
-	  scatter_access(ii, field_var::jfz) += q*uz;
-	  scatter_access(ii, field_var::rhof) += q;
+#ifdef SHAPE_NGP
+	  scatter_access(ii, field_var::jfx) += q*rV*ux;
+	  scatter_access(ii, field_var::jfy) += q*rV*uy;
+	  scatter_access(ii, field_var::jfz) += q*rV*uz;
+	  scatter_access(ii, field_var::rhof) += q*rV;
+#else
+#ifdef SHAPE_QS
+          // stencil coefficients
+          // ... OLD hybrid-VPIC with QS shape, the accumulator stores
+          // ... ... p->w*qsp * two*(three - ...)
+          // ... ... hyb_unload_accumulator(...) applies factor rV/12.
+          // ... NEW HVPIC-K not using accumulator (yet), scatter directly to mesh,
+          // ... ... so include all factors
+          w0 =  q*rV12*two*( three - x_half*x_half - y_half*y_half - z_half*z_half );
+          wx =  q*rV12*( x_half + one )*( x_half + one );
+          wy =  q*rV12*( y_half + one )*( y_half + one );
+          wz =  q*rV12*( z_half + one )*( z_half + one );
+          wmx = q*rV12*( x_half - one )*( x_half - one );
+          wmy = q*rV12*( y_half - one )*( y_half - one );
+          wmz = q*rV12*( z_half - one )*( z_half - one );
+
+          // Voxel indices
+          int iii = ii;
+          int zi = iii/((nx+2)*(ny+2));
+          iii -= zi*(nx+2)*(ny+2);
+          int yi = iii/(nx+2);
+          int xi = iii-yi*(nx+2);
+          // Neighboring voxel 1D (flattened) indices
+          int iix = VOXEL(xi+1,yi,zi,nx,ny,nz);
+          int iiy = VOXEL(xi,yi+1,zi,nx,ny,nz);
+          int iiz = VOXEL(xi,yi,zi+1,nx,ny,nz);
+          int iimx = VOXEL(xi-1,yi,zi,nx,ny,nz);
+          int iimy = VOXEL(xi,yi-1,zi,nx,ny,nz);
+          int iimz = VOXEL(xi,yi,zi-1,nx,ny,nz);
+
+          scatter_access(ii, field_var::jfx)  += w0*ux;
+          scatter_access(ii, field_var::jfy)  += w0*uy;
+          scatter_access(ii, field_var::jfz)  += w0*uz;
+          scatter_access(ii, field_var::rhof) += w0;
+
+          scatter_access(iix, field_var::jfx)  += wx*ux;
+          scatter_access(iix, field_var::jfy)  += wx*uy;
+          scatter_access(iix, field_var::jfz)  += wx*uz;
+          scatter_access(iix, field_var::rhof) += wx;
+
+          scatter_access(iiy, field_var::jfx)  += wy*ux;
+          scatter_access(iiy, field_var::jfy)  += wy*uy;
+          scatter_access(iiy, field_var::jfz)  += wy*uz;
+          scatter_access(iiy, field_var::rhof) += wy;
+
+          scatter_access(iiz, field_var::jfx)  += wz*ux;
+          scatter_access(iiz, field_var::jfy)  += wz*uy;
+          scatter_access(iiz, field_var::jfz)  += wz*uz;
+          scatter_access(iiz, field_var::rhof) += wz;
+
+          scatter_access(iimx, field_var::jfx)  += wmx*ux;
+          scatter_access(iimx, field_var::jfy)  += wmx*uy;
+          scatter_access(iimx, field_var::jfz)  += wmx*uz;
+          scatter_access(iimx, field_var::rhof) += wmx;
+
+          scatter_access(iimy, field_var::jfx)  += wmy*ux;
+          scatter_access(iimy, field_var::jfy)  += wmy*uy;
+          scatter_access(iimy, field_var::jfz)  += wmy*uz;
+          scatter_access(iimy, field_var::rhof) += wmy;
+
+          scatter_access(iimz, field_var::jfx)  += wmz*ux;
+          scatter_access(iimz, field_var::jfy)  += wmz*uy;
+          scatter_access(iimz, field_var::jfz)  += wmz*uz;
+          scatter_access(iimz, field_var::rhof) += wmz;
+#endif // defined(SHAPE_QS)
+#endif // defined(SHAPE_NGP)
 	//}
 	
 	
@@ -759,9 +823,10 @@ move_p_kokkos_host_serial(
   const int nz = g->nz;
 
   float ux,uy,uz,u,absdisp,x_half,y_half,z_half,fracdt;
-  const float one=1., two=2., three=3.;
+  const float one=1., two=2., three=3., one_twelfth=1./12.;
   const float gdx=g->dx, gdy=g->dy, gdz=g->dz, gdt=g->dt;
   const float rV = g->rdx * g->rdy * g->rdz;
+  const float rV12 = rV*one_twelfth;
 
   float cx = 0.25 * g->rdy * g->rdz / g->dt;
   float cy = 0.25 * g->rdz * g->rdx / g->dt;
@@ -789,6 +854,7 @@ move_p_kokkos_host_serial(
   float s_dispx, s_dispy, s_dispz;
   float s_dir[3];
   float v0, v1, v2, v3, v4, v5, q;
+  float w0, wx, wy, wz, wmx, wmy, wmz;
   int axis, face;
   int64_t neighbor;
   //int pi = int(local_pm_i);
@@ -799,6 +865,7 @@ move_p_kokkos_host_serial(
 #else
   q = qsp*p_w;
 #endif
+
     //printf("in move %d \n", pi);
 
   for(;;) {
@@ -843,17 +910,79 @@ move_p_kokkos_host_serial(
 	 && -x_half<=one && -y_half<=one && -z_half<=one) {
         
 	// Accumulate the particle current density
-	
-      //int iii = ii;
-      //int zi = iii/((nx+2)*(ny+2));
-      //iii -= zi*(nx+2)*(ny+2);
-      //int yi = iii/(nx+2);
-      //int xi = iii-yi*(nx+2);
-      
-      k_jf_accum(ii, accumulator_var::jx) += rV*q*ux;
-      k_jf_accum(ii, accumulator_var::jy) += rV*q*uy;
-      k_jf_accum(ii, accumulator_var::jz) += rV*q*uz;
-      k_jf_accum(ii, accumulator_var::rho) += rV*q;
+
+#ifdef SHAPE_NGP
+        k_jf_accum(ii, accumulator_var::jx) += q*rV*ux;
+        k_jf_accum(ii, accumulator_var::jy) += q*rV*uy;
+        k_jf_accum(ii, accumulator_var::jz) += q*rV*uz;
+        k_jf_accum(ii, accumulator_var::rho) += q*rV;
+#else
+#ifdef SHAPE_QS
+        // stencil coefficients
+        // ... OLD hybrid-VPIC with QS shape, the accumulator stores
+        // ... ... p->w*qsp * two*(three - ...)
+        // ... ... hyb_unload_accumulator(...) applies factor rV/12.
+        // ... NEW HVPIC-K not using accumulator (yet), scatter directly to mesh,
+        // ... ... so include all factors
+        w0 =  q*rV12*two*( three - x_half*x_half - y_half*y_half - z_half*z_half );
+        wx =  q*rV12*( x_half + one )*( x_half + one );
+        wy =  q*rV12*( y_half + one )*( y_half + one );
+        wz =  q*rV12*( z_half + one )*( z_half + one );
+        wmx = q*rV12*( x_half - one )*( x_half - one );
+        wmy = q*rV12*( y_half - one )*( y_half - one );
+        wmz = q*rV12*( z_half - one )*( z_half - one );
+
+        // Voxel indices
+        int iii = ii;
+        int zi = iii/((nx+2)*(ny+2));
+        iii -= zi*(nx+2)*(ny+2);
+        int yi = iii/(nx+2);
+        int xi = iii-yi*(nx+2);
+        // Neighboring voxel 1D (flattened) indices
+        int iix = VOXEL(xi+1,yi,zi,nx,ny,nz);
+        int iiy = VOXEL(xi,yi+1,zi,nx,ny,nz);
+        int iiz = VOXEL(xi,yi,zi+1,nx,ny,nz);
+        int iimx = VOXEL(xi-1,yi,zi,nx,ny,nz);
+        int iimy = VOXEL(xi,yi-1,zi,nx,ny,nz);
+        int iimz = VOXEL(xi,yi,zi-1,nx,ny,nz);
+
+        k_jf_accum(ii, accumulator_var::jx)  += w0*ux;
+        k_jf_accum(ii, accumulator_var::jy)  += w0*uy;
+        k_jf_accum(ii, accumulator_var::jz)  += w0*uz;
+        k_jf_accum(ii, accumulator_var::rho) += w0;
+
+        k_jf_accum(iix, accumulator_var::jx)  += wx*ux;
+        k_jf_accum(iix, accumulator_var::jy)  += wx*uy;
+        k_jf_accum(iix, accumulator_var::jz)  += wx*uz;
+        k_jf_accum(iix, accumulator_var::rho) += wx;
+
+        k_jf_accum(iiy, accumulator_var::jx)  += wy*ux;
+        k_jf_accum(iiy, accumulator_var::jy)  += wy*uy;
+        k_jf_accum(iiy, accumulator_var::jz)  += wy*uz;
+        k_jf_accum(iiy, accumulator_var::rho) += wy;
+
+        k_jf_accum(iiz, accumulator_var::jx)  += wz*ux;
+        k_jf_accum(iiz, accumulator_var::jy)  += wz*uy;
+        k_jf_accum(iiz, accumulator_var::jz)  += wz*uz;
+        k_jf_accum(iiz, accumulator_var::rho) += wz;
+
+        k_jf_accum(iimx, accumulator_var::jx)  += wmx*ux;
+        k_jf_accum(iimx, accumulator_var::jy)  += wmx*uy;
+        k_jf_accum(iimx, accumulator_var::jz)  += wmx*uz;
+        k_jf_accum(iimx, accumulator_var::rho) += wmx;
+
+        k_jf_accum(iimy, accumulator_var::jx)  += wmy*ux;
+        k_jf_accum(iimy, accumulator_var::jy)  += wmy*uy;
+        k_jf_accum(iimy, accumulator_var::jz)  += wmy*uz;
+        k_jf_accum(iimy, accumulator_var::rho) += wmy;
+
+        k_jf_accum(iimz, accumulator_var::jx)  += wmz*ux;
+        k_jf_accum(iimz, accumulator_var::jy)  += wmz*uy;
+        k_jf_accum(iimz, accumulator_var::jz)  += wmz*uz;
+        k_jf_accum(iimz, accumulator_var::rho) += wmz;
+#endif // defined(SHAPE_QS)
+#endif // defined(SHAPE_NGP)
+
       } //if indbds
       
     } //ifmore than half dt left

--- a/src/species_advance/standard/advance_p.cc
+++ b/src/species_advance/standard/advance_p.cc
@@ -185,7 +185,7 @@ template<int N>
 KOKKOS_INLINE_FUNCTION
 void unrolled_simd_load(float* vals, const int* ii, const k_interpolator_t& k_interp, int len) {
   unrolled_simd_load<N-1>(vals, ii, k_interp, len);
-  simd_load_interpolator_var(vals+(N-1)*18, ii[N-1], k_interp, len);
+  simd_load_interpolator_var(vals+(N-1)*INTERPOLATOR_VAR_COUNT, ii[N-1], k_interp, len);
 }
 template<>
 KOKKOS_INLINE_FUNCTION
@@ -204,23 +204,11 @@ template<int NumLanes>
 KOKKOS_INLINE_FUNCTION
 void load_interpolators(
                         float* fex,
-                        float* fdexdy,
-                        float* fdexdz,
-                        float* fd2exdydz,
                         float* fey,
-                        float* fdeydz,
-                        float* fdeydx,
-                        float* fd2eydzdx,
                         float* fez,
-                        float* fdezdx,
-                        float* fdezdy,
-                        float* fd2ezdxdy,
                         float* fcbx,
-                        float* fdcbxdx,
                         float* fcby,
-                        float* fdcbydy,
                         float* fcbz,
-                        float* fdcbzdz,
                         const int* ii,
 			const int num_part,
                         const k_interpolator_t& k_interp
@@ -236,81 +224,45 @@ void load_interpolators(
 
   // Try to reduce the number of loads if all particles are in the same cell
   if(same_cell) {
-    float vals[18];
+    float vals[INTERPOLATOR_VAR_COUNT];
 
-    simd_load_interpolator_var(vals, ii[0], k_interp, 18);
+    simd_load_interpolator_var(vals, ii[0], k_interp, INTERPOLATOR_VAR_COUNT);
     #pragma omp simd
     for(int i=0; i<NumLanes; i++) {
       fex[i]       = vals[0];
-      //fdexdy[i]    = vals[1];
-      //fdexdz[i]    = vals[2];
-      //fd2exdydz[i] = vals[3];
-      fey[i]       = vals[4];
-      //fdeydz[i]    = vals[5];
-      //fdeydx[i]    = vals[6];
-      //fd2eydzdx[i] = vals[7];
-      fez[i]       = vals[8];
-      //fdezdx[i]    = vals[9];
-      //fdezdy[i]    = vals[10];
-      //fd2ezdxdy[i] = vals[11];
-      fcbx[i]      = vals[12];
-      //fdcbxdx[i]   = vals[13];
-      fcby[i]      = vals[14];
-      //fdcbydy[i]   = vals[15];
-      fcbz[i]      = vals[16];
-      //dcbzdz[i]   = vals[17];
+      fey[i]       = vals[1];
+      fez[i]       = vals[2];
+      fcbx[i]      = vals[3];
+      fcby[i]      = vals[4];
+      fcbz[i]      = vals[5];
     }
   } else {
 
     // Efficient vectorized load
-    float vals[18*NumLanes];
-    unrolled_simd_load(vals, ii, k_interp, 18, num_part);
-//    unrolled_simd_load<NumLanes>(vals, ii, k_interp, 18);
+    float vals[INTERPOLATOR_VAR_COUNT*NumLanes];
+    unrolled_simd_load(vals, ii, k_interp, INTERPOLATOR_VAR_COUNT, num_part);
+//    unrolled_simd_load<NumLanes>(vals, ii, k_interp, INTERPOLATOR_VAR_COUNT);
 
     // Essentially a transpose
     #pragma omp simd
     for(int i=0; i<num_part; i++) {
-      fex[i]       = vals[18*i];
-      //fdexdy[i]    = vals[1+18*i];
-      //fdexdz[i]    = vals[2+18*i];
-      //fd2exdydz[i] = vals[3+18*i];
-      fey[i]       = vals[4+18*i];
-      //fdeydz[i]    = vals[5+18*i];
-      //fdeydx[i]    = vals[6+18*i];
-      //fd2eydzdx[i] = vals[7+18*i];
-      fez[i]       = vals[8+18*i];
-      //fdezdx[i]    = vals[9+18*i];
-      //fdezdy[i]    = vals[10+18*i];
-      //fd2ezdxdy[i] = vals[11+18*i];
-      fcbx[i]      = vals[12+18*i];
-      //fdcbxdx[i]   = vals[13+18*i];
-      fcby[i]      = vals[14+18*i];
-      //fdcbydy[i]   = vals[15+18*i];
-      fcbz[i]      = vals[16+18*i];
-      //fdcbzdz[i]   = vals[17+18*i];
+      fex[i]       = vals[  INTERPOLATOR_VAR_COUNT*i];
+      fey[i]       = vals[1+INTERPOLATOR_VAR_COUNT*i];
+      fez[i]       = vals[2+INTERPOLATOR_VAR_COUNT*i];
+      fcbx[i]      = vals[3+INTERPOLATOR_VAR_COUNT*i];
+      fcby[i]      = vals[4+INTERPOLATOR_VAR_COUNT*i];
+      fcbz[i]      = vals[5+INTERPOLATOR_VAR_COUNT*i];
     }
   }
 #else
   for(int lane=0; lane<NumLanes; lane++) {
     // Load interpolators
     fex[LANE]       = k_interp(ii[LANE], interpolator_var::ex);     
-    //fdexdy[LANE]    = k_interp(ii[LANE], interpolator_var::dexdy);  
-    //fdexdz[LANE]    = k_interp(ii[LANE], interpolator_var::dexdz);  
-    //fd2exdydz[LANE] = k_interp(ii[LANE], interpolator_var::d2exdydz);
     fey[LANE]       = k_interp(ii[LANE], interpolator_var::ey);     
-    //fdeydz[LANE]    = k_interp(ii[LANE], interpolator_var::deydz);  
-    //fdeydx[LANE]    = k_interp(ii[LANE], interpolator_var::deydx);  
-    //fd2eydzdx[LANE] = k_interp(ii[LANE], interpolator_var::d2eydzdx);
     fez[LANE]       = k_interp(ii[LANE], interpolator_var::ez);     
-    //fdezdx[LANE]    = k_interp(ii[LANE], interpolator_var::dezdx);  
-    //fdezdy[LANE]    = k_interp(ii[LANE], interpolator_var::dezdy);  
-    //fd2ezdxdy[LANE] = k_interp(ii[LANE], interpolator_var::d2ezdxdy);
     fcbx[LANE]      = k_interp(ii[LANE], interpolator_var::cbx);    
-    //fdcbxdx[LANE]   = k_interp(ii[LANE], interpolator_var::dcbxdx); 
     fcby[LANE]      = k_interp(ii[LANE], interpolator_var::cby);    
-    //fdcbydy[LANE]   = k_interp(ii[LANE], interpolator_var::dcbydy); 
     fcbz[LANE]      = k_interp(ii[LANE], interpolator_var::cbz);    
-    //fdcbzdz[LANE]   = k_interp(ii[LANE], interpolator_var::dcbzdz); 
   }
 #endif
 }
@@ -483,26 +435,16 @@ advance_p_kokkos_unified(
       float fex[num_lanes];
       float fey[num_lanes];
       float fez[num_lanes];
-      float fdexdy[num_lanes];
-      float fdexdz[num_lanes];
-      float fd2exdydz[num_lanes];
-      float fdeydx[num_lanes];
-      float fdeydz[num_lanes];
-      float fd2eydzdx[num_lanes];
-      float fdezdx[num_lanes];
-      float fdezdy[num_lanes];
-      float fd2ezdxdy[num_lanes];
-      float fdcbxdx[num_lanes];
-      float fdcbydy[num_lanes];
-      float fdcbzdz[num_lanes];
+      float tmp0[num_lanes];
+      float tmp1[num_lanes];
       float *v6 = fex;
-      float *v7 = fdexdy;
-      float *v8 = fdexdz;
-      float *v9 = fd2exdydz;
-      float *v10 = fey;
-      float *v11 = fdeydz;
-      float *v12 = fdeydx;
-      float *v13 = fd2eydzdx;
+      float *v7 = fey;
+      float *v8 = fez;
+      float *v9 = fcbx;
+      float *v10 = fcby;
+      float *v11 = fcbz;
+      float *v12 = tmp0;
+      float *v13 = tmp1;
 
       size_t p_index = pi_offset;
 
@@ -526,12 +468,7 @@ advance_p_kokkos_unified(
         ii[LANE] = pii;
       } END_VECTOR_BLOCK;
 
-      load_interpolators<num_lanes>( fex, fdexdy, fdexdz, fd2exdydz,
-                                     fey, fdeydz, fdeydx, fd2eydzdx,
-                                     fez, fdezdx, fdezdy, fd2ezdxdy,
-                                     fcbx, fdcbxdx,
-                                     fcby, fdcbydy,
-                                     fcbz, fdcbzdz,
+      load_interpolators<num_lanes>( fex, fey, fez, fcbx, fcby, fcbz,
                                      ii, num_particles, k_interp);
 
       BEGIN_VECTOR_BLOCK {

--- a/src/species_advance/standard/advance_p.cc
+++ b/src/species_advance/standard/advance_p.cc
@@ -17,25 +17,83 @@ accumulate_current(CurrentScatterAccess& current_sa, int ii,
                    const float v0, const float v1, const float v2, const float v3,
                    const float v4, const float v5, const float v6, const float v7,
                    const float v8, const float v9, const float v10, const float v11) {
-#ifdef VPIC_ENABLE_ACCUMULATORS
-  current_sa(ii, 0)  += v0;
-  //current_sa(ii, 1)  += cx*v1;
-  //current_sa(ii, 2)  += cx*v2;
-  //current_sa(ii, 3)  += cx*v3; 
-  current_sa(ii, 4)  += v1;
-  current_sa(ii, 8)  += v2;
- 
+#ifdef SHAPE_NGP
+#   ifdef VPIC_ENABLE_ACCUMULATORS
+      current_sa(ii, 0)  += v0;
+      //current_sa(ii, 1)  += cx*v1;
+      //current_sa(ii, 2)  += cx*v2;
+      //current_sa(ii, 3)  += cx*v3;
+      current_sa(ii, 4)  += v1;
+      current_sa(ii, 8)  += v2;
+#   else
+      int iii = ii;
+      int zi = iii/((nx+2)*(ny+2));
+      iii -= zi*(nx+2)*(ny+2);
+      int yi = iii/(nx+2);
+      int xi = iii - yi*(nx+2);
+      current_sa(ii, field_var::jfx)                           += v0;
+      current_sa(ii, field_var::jfy)                           += v1;
+      current_sa(ii, field_var::jfz)                           += v2;
+      current_sa(ii, field_var::rhof)                          += v3;
+#   endif
 #else
-  int iii = ii;
-  int zi = iii/((nx+2)*(ny+2));
-  iii -= zi*(nx+2)*(ny+2);
-  int yi = iii/(nx+2);
-  int xi = iii - yi*(nx+2);
-  current_sa(ii, field_var::jfx)                           += v0;
-  current_sa(ii, field_var::jfy)                           += v1;
-  current_sa(ii, field_var::jfz)                           += v2;
-  current_sa(ii, field_var::rhof)                          += v3;
-#endif
+#ifdef SHAPE_QS
+#   ifdef VPIC_ENABLE_ACCUMULATORS
+      // not handling VPIC_ENABLE_ACCUMULATORS case
+      // so fail loudly by not depositing anything
+      Kokkos::abort("shape_qs lacks support for VPIC_ENABLE_ACCUMULATORS");
+#   else
+      // Voxel indices
+      int iii = ii;
+      int zi = iii/((nx+2)*(ny+2));
+      iii -= zi*(nx+2)*(ny+2);
+      int yi = iii/(nx+2);
+      int xi = iii - yi*(nx+2);
+      // Neighboring voxel 1D (flattened) indices
+      int iix = VOXEL(xi+1,yi,zi,nx,ny,nz);
+      int iiy = VOXEL(xi,yi+1,zi,nx,ny,nz);
+      int iiz = VOXEL(xi,yi,zi+1,nx,ny,nz);
+      int iimx = VOXEL(xi-1,yi,zi,nx,ny,nz);
+      int iimy = VOXEL(xi,yi-1,zi,nx,ny,nz);
+      int iimz = VOXEL(xi,yi,zi-1,nx,ny,nz);
+
+      current_sa(ii, field_var::jfx)  += v3*v6; // w0*ux;
+      current_sa(ii, field_var::jfy)  += v3*v7; // w0*uy;
+      current_sa(ii, field_var::jfz)  += v3*v8; // w0*uz;
+      current_sa(ii, field_var::rhof) += v3;    // w0;
+
+      current_sa(iix, field_var::jfx)  += v4*v6; // wx*ux;
+      current_sa(iix, field_var::jfy)  += v4*v7; // wx*uy;
+      current_sa(iix, field_var::jfz)  += v4*v8; // wx*uz;
+      current_sa(iix, field_var::rhof) += v4;    // wx;
+
+      current_sa(iiy, field_var::jfx)  += v5*v6; // wy*ux;
+      current_sa(iiy, field_var::jfy)  += v5*v7; // wy*uy;
+      current_sa(iiy, field_var::jfz)  += v5*v8; // wy*uz;
+      current_sa(iiy, field_var::rhof) += v5;    // wy;
+
+      current_sa(iiz, field_var::jfx)  += v9*v6; // wz*ux;
+      current_sa(iiz, field_var::jfy)  += v9*v7; // wz*uy;
+      current_sa(iiz, field_var::jfz)  += v9*v8; // wz*uz;
+      current_sa(iiz, field_var::rhof) += v9;    // wz;
+
+      current_sa(iimx, field_var::jfx)  += v0*v6; // wmx*ux;
+      current_sa(iimx, field_var::jfy)  += v0*v7; // wmx*uy;
+      current_sa(iimx, field_var::jfz)  += v0*v8; // wmx*uz;
+      current_sa(iimx, field_var::rhof) += v0;    // wmx;
+
+      current_sa(iimy, field_var::jfx)  += v1*v6; // wmy*ux;
+      current_sa(iimy, field_var::jfy)  += v1*v7; // wmy*uy;
+      current_sa(iimy, field_var::jfz)  += v1*v8; // wmy*uz;
+      current_sa(iimy, field_var::rhof) += v1;    // wmy;
+
+      current_sa(iimz, field_var::jfx)  += v2*v6; // wmz*ux;
+      current_sa(iimz, field_var::jfy)  += v2*v7; // wmz*uy;
+      current_sa(iimz, field_var::jfz)  += v2*v8; // wmz*uz;
+      current_sa(iimz, field_var::rhof) += v2;    // wmz;
+#   endif
+#endif // defined(SHAPE_QS)
+#endif // defined(SHAPE_NGP)
 }
 
 // Reduce the current for all active threads/lanes to reduce the number of writes to memory
@@ -523,6 +581,7 @@ advance_p_kokkos_unified(
   constexpr float one            = 1.;
   constexpr float one_third      = 1./3.;
   constexpr float two_fifteenths = 2./15.;
+  constexpr float one_twelfth    = 1./12.;
 
   k_field_t k_field = fa->k_f_d;
   float cx = 0.25 * g->rdy * g->rdz / g->dt;
@@ -888,14 +947,23 @@ advance_p_kokkos_unified(
         //dz[LANE] = v2[LANE];
         //v5[LANE] = q[LANE]*ux[LANE]*uy[LANE]*uz[LANE]*one_third;
 
-#       define ACCUMULATE_J()                                              \
-        v0[LANE]  = q[LANE]*v6[LANE];   /*  = q ux                            */        \
-        v1[LANE]  = q[LANE]*v7[LANE];   /*  = q uy                            */        \
-        v2[LANE]  = q[LANE]*v8[LANE];   /*  = q uz                            */        \
-        v3[LANE]  = q[LANE];   /* v2 = q                            */        \
-      
-        ACCUMULATE_J();
-
+#ifdef SHAPE_NGP
+        v0[LANE]  = q[LANE]*v6[LANE]; // q*ux
+        v1[LANE]  = q[LANE]*v7[LANE]; // q*uy
+        v2[LANE]  = q[LANE]*v8[LANE]; // q*uz
+        v3[LANE]  = q[LANE];
+#else
+#ifdef SHAPE_QS
+        q[LANE] *= one_twelfth;
+        v3[LANE] = q[LANE]*two*( three - v0[LANE]*v0[LANE] - v1[LANE]*v1[LANE] - v2[LANE]*v2[LANE] );  // w0
+        v4[LANE] = q[LANE]*( v0[LANE] + one )*( v0[LANE] + one );  // wx
+        v5[LANE] = q[LANE]*( v1[LANE] + one )*( v1[LANE] + one );  // wy
+        v9[LANE] = q[LANE]*( v2[LANE] + one )*( v2[LANE] + one );  // wz
+        v0[LANE] = q[LANE]*( v0[LANE] - one )*( v0[LANE] - one );  // wmx  // re-use due to limited number of slots
+        v1[LANE] = q[LANE]*( v1[LANE] - one )*( v1[LANE] - one );  // wmy  // in accumulate_current(...) signature
+        v2[LANE] = q[LANE]*( v2[LANE] - one )*( v2[LANE] - one );  // wmz
+#endif
+#endif
 
       } END_VECTOR_BLOCK;
 
@@ -913,8 +981,8 @@ advance_p_kokkos_unified(
           accumulate_current(current_sa, ii[LANE],
                        nx, ny, nz, rV,
 		       v0[LANE], v1[LANE], v2[LANE], v3[LANE],
-                       v6[LANE], v7[LANE], v8[LANE], v9[LANE],
-                       v10[LANE], v11[LANE], v12[LANE], v13[LANE]);
+                       v4[LANE], v5[LANE], v6[LANE], v7[LANE],
+                       v8[LANE], v9[LANE], v10[LANE], v11[LANE]);
         } END_VECTOR_BLOCK;
 #ifdef VPIC_ENABLE_TEAM_REDUCTION
       }

--- a/src/species_advance/standard/advance_p.cc
+++ b/src/species_advance/standard/advance_p.cc
@@ -759,15 +759,19 @@ advance_p_kokkos_gpu(
         const int nz)
 {
 
+  constexpr float three          = 3.;
+  constexpr float two            = 2.;
   constexpr float one            = 1.;
   constexpr float one_third      = 1./3.;
   constexpr float two_fifteenths = 2./15.;
+  constexpr float one_twelfth    = 1./12.;
   k_field_t k_field = fa->k_f_d;
   k_field_sa_t k_f_sv = Kokkos::Experimental::create_scatter_view<>(k_field);
   float cx = 0.25 * g->rdy * g->rdz / g->dt;
   float cy = 0.25 * g->rdz * g->rdx / g->dt;
   float cz = 0.25 * g->rdx * g->rdy / g->dt;
   float rV = g->rdx*g->rdy*g->rdz;
+  float rV12 = rV*one_twelfth;
   float gdx=g->dx, gdy=g->dy, gdz = g->dz, gdt = g->dt;
 
 
@@ -785,28 +789,48 @@ advance_p_kokkos_gpu(
 #endif
   #define pii     k_particles_i(p_index)
 
-  #define f_cbx k_interp(ii, interpolator_var::cbx)
-  #define f_cby k_interp(ii, interpolator_var::cby)
-  #define f_cbz k_interp(ii, interpolator_var::cbz)
-  #define f_ex  k_interp(ii, interpolator_var::ex)
-  #define f_ey  k_interp(ii, interpolator_var::ey)
-  #define f_ez  k_interp(ii, interpolator_var::ez)
-
+  #define f_ex       k_interp(ii, interpolator_var::ex)
+  #define f_dexdx    k_interp(ii, interpolator_var::dexdx)
   #define f_dexdy    k_interp(ii, interpolator_var::dexdy)
   #define f_dexdz    k_interp(ii, interpolator_var::dexdz)
-
-  #define f_d2exdydz k_interp(ii, interpolator_var::d2exdydz)
+  #define f_d2exdx   k_interp(ii, interpolator_var::d2exdx)
+  #define f_d2exdy   k_interp(ii, interpolator_var::d2exdy)
+  #define f_d2exdz   k_interp(ii, interpolator_var::d2exdz)
+  #define f_ey       k_interp(ii, interpolator_var::ey)
   #define f_deydx    k_interp(ii, interpolator_var::deydx)
+  #define f_deydy    k_interp(ii, interpolator_var::deydy)
   #define f_deydz    k_interp(ii, interpolator_var::deydz)
-
-  #define f_d2eydzdx k_interp(ii, interpolator_var::d2eydzdx)
+  #define f_d2eydx   k_interp(ii, interpolator_var::d2eydx)
+  #define f_d2eydy   k_interp(ii, interpolator_var::d2eydy)
+  #define f_d2eydz   k_interp(ii, interpolator_var::d2eydz)
+  #define f_ez       k_interp(ii, interpolator_var::ez)
   #define f_dezdx    k_interp(ii, interpolator_var::dezdx)
   #define f_dezdy    k_interp(ii, interpolator_var::dezdy)
-
-  #define f_d2ezdxdy k_interp(ii, interpolator_var::d2ezdxdy)
+  #define f_dezdz    k_interp(ii, interpolator_var::dezdz)
+  #define f_d2ezdx   k_interp(ii, interpolator_var::d2ezdx)
+  #define f_d2ezdy   k_interp(ii, interpolator_var::d2ezdy)
+  #define f_d2ezdz   k_interp(ii, interpolator_var::d2ezdz)
+  #define f_cbx      k_interp(ii, interpolator_var::cbx)
   #define f_dcbxdx   k_interp(ii, interpolator_var::dcbxdx)
+  #define f_dcbxdy   k_interp(ii, interpolator_var::dcbxdy)
+  #define f_dcbxdz   k_interp(ii, interpolator_var::dcbxdz)
+  #define f_d2cbxdx  k_interp(ii, interpolator_var::d2cbxdx)
+  #define f_d2cbxdy  k_interp(ii, interpolator_var::d2cbxdy)
+  #define f_d2cbxdz  k_interp(ii, interpolator_var::d2cbxdz)
+  #define f_cby      k_interp(ii, interpolator_var::cby)
+  #define f_dcbydx   k_interp(ii, interpolator_var::dcbydx)
   #define f_dcbydy   k_interp(ii, interpolator_var::dcbydy)
+  #define f_dcbydz   k_interp(ii, interpolator_var::dcbydz)
+  #define f_d2cbydx  k_interp(ii, interpolator_var::d2cbydx)
+  #define f_d2cbydy  k_interp(ii, interpolator_var::d2cbydy)
+  #define f_d2cbydz  k_interp(ii, interpolator_var::d2cbydz)
+  #define f_cbz      k_interp(ii, interpolator_var::cbz)
+  #define f_dcbzdx   k_interp(ii, interpolator_var::dcbzdx)
+  #define f_dcbzdy   k_interp(ii, interpolator_var::dcbzdy)
   #define f_dcbzdz   k_interp(ii, interpolator_var::dcbzdz)
+  #define f_d2cbzdx  k_interp(ii, interpolator_var::d2cbzdx)
+  #define f_d2cbzdy  k_interp(ii, interpolator_var::d2cbzdy)
+  #define f_d2cbzdz  k_interp(ii, interpolator_var::d2cbzdz)
 
   // copy local memmbers from grid
   //auto nfaces_per_voxel = 6;
@@ -837,6 +861,7 @@ advance_p_kokkos_gpu(
 #endif
       
     float v0, v1, v2, v3, v4, v5, v6;
+    float w0, wx, wy, wz, wmx, wmy, wmz;
     auto  k_field_scatter_access = k_f_sv.access();
 
 #ifdef VARIABLE_CHARGE
@@ -848,13 +873,37 @@ advance_p_kokkos_gpu(
     float dy   = p_dy;
     float dz   = p_dz;
     int   ii   = pii;
+#ifdef SHAPE_NGP
     float hax  = qdt_2mc*(    ( f_ex ) );
     float hay  = qdt_2mc*(    ( f_ey ) );
     float haz  = qdt_2mc*(    ( f_ez  ) );
-
     float cbx  = f_cbx;// + dx*f_dcbxdx;             // Interpolate B
     float cby  = f_cby;// + dy*f_dcbydy;
     float cbz  = f_cbz;// + dz*f_dcbzdz;
+#else
+#ifdef SHAPE_QS
+    // Interpolate E
+    float hax  = qdt_2mc*( f_ex + dx*( f_dexdx + dx*f_d2exdx )
+                                + dy*( f_dexdy + dy*f_d2exdy )
+                                + dz*( f_dexdz + dz*f_d2exdz ) );
+    float hay  = qdt_2mc*( f_ey + dx*( f_deydx + dx*f_d2eydx )
+                                + dy*( f_deydy + dy*f_d2eydy )
+                                + dz*( f_deydz + dz*f_d2eydz ) );
+    float haz  = qdt_2mc*( f_ez + dx*( f_dezdx + dx*f_d2ezdx )
+                                + dy*( f_dezdy + dy*f_d2ezdy )
+                                + dz*( f_dezdz + dz*f_d2ezdz ) );
+    // Interpolate B
+    float cbx  = f_cbx + dx*( f_dcbxdx + dx*f_d2cbxdx )
+                       + dy*( f_dcbxdy + dy*f_d2cbxdy )
+                       + dz*( f_dcbxdz + dz*f_d2cbxdz );
+    float cby  = f_cby + dx*( f_dcbydx + dx*f_d2cbydx )
+                       + dy*( f_dcbydy + dy*f_d2cbydy )
+                       + dz*( f_dcbydz + dz*f_d2cbydz );
+    float cbz  = f_cbz + dx*( f_dcbzdx + dx*f_d2cbzdx )
+                       + dy*( f_dcbzdy + dy*f_d2cbzdy )
+                       + dz*( f_dcbzdz + dz*f_d2cbzdz );
+#endif
+#endif
     float ux   = p_ux;                             // Load momentum
     float uy   = p_uy;
     float uz   = p_uz;
@@ -977,10 +1026,80 @@ advance_p_kokkos_gpu(
         //int yi = iii/(nx+2);
         //int xi = iii - yi*(nx+2);
       
-           k_field_scatter_access(ii, field_var::jfx) += q*rV*ux;
-           k_field_scatter_access(ii, field_var::jfy) += q*rV*uy;
-           k_field_scatter_access(ii, field_var::jfz) += q*rV*uz;
-	   k_field_scatter_access(ii, field_var::rhof) += q*rV;
+#ifdef SHAPE_NGP
+      q *= rV;
+      k_field_scatter_access(ii, field_var::jfx) += q*ux;
+      k_field_scatter_access(ii, field_var::jfy) += q*uy;
+      k_field_scatter_access(ii, field_var::jfz) += q*uz;
+      k_field_scatter_access(ii, field_var::rhof) += q;
+#else
+#ifdef SHAPE_QS
+      // stencil coefficients
+      // ... OLD hybrid-VPIC with QS shape, the accumulator stores
+      // ... ... p->w*qsp * two*(three - ...)
+      // ... ... hyb_unload_accumulator(...) applies factor rV/12.
+      // ... NEW HVPIC-K not using accumulator (yet), scatter directly to mesh,
+      // ... ... so include all factors
+      q *= rV12;
+      w0 =  q*two*( three - v0*v0 - v1*v1 - v2*v2 );
+      wx =  q*( v0 + one )*( v0 + one );
+      wy =  q*( v1 + one )*( v1 + one );
+      wz =  q*( v2 + one )*( v2 + one );
+      wmx = q*( v0 - one )*( v0 - one );
+      wmy = q*( v1 - one )*( v1 - one );
+      wmz = q*( v2 - one )*( v2 - one );
+
+      // Voxel indices
+      int iii = ii;
+      int zi = iii/((nx+2)*(ny+2));
+      iii -= zi*(nx+2)*(ny+2);
+      int yi = iii/(nx+2);
+      int xi = iii - yi*(nx+2);
+      // Neighboring voxel 1D (flattened) indices
+      int iix = VOXEL(xi+1,yi,zi,nx,ny,nz);
+      int iiy = VOXEL(xi,yi+1,zi,nx,ny,nz);
+      int iiz = VOXEL(xi,yi,zi+1,nx,ny,nz);
+      int iimx = VOXEL(xi-1,yi,zi,nx,ny,nz);
+      int iimy = VOXEL(xi,yi-1,zi,nx,ny,nz);
+      int iimz = VOXEL(xi,yi,zi-1,nx,ny,nz);
+
+      k_field_scatter_access(ii, field_var::jfx)  += w0*ux;
+      k_field_scatter_access(ii, field_var::jfy)  += w0*uy;
+      k_field_scatter_access(ii, field_var::jfz)  += w0*uz;
+      k_field_scatter_access(ii, field_var::rhof) += w0;
+
+      k_field_scatter_access(iix, field_var::jfx)  += wx*ux;
+      k_field_scatter_access(iix, field_var::jfy)  += wx*uy;
+      k_field_scatter_access(iix, field_var::jfz)  += wx*uz;
+      k_field_scatter_access(iix, field_var::rhof) += wx;
+
+      k_field_scatter_access(iiy, field_var::jfx)  += wy*ux;
+      k_field_scatter_access(iiy, field_var::jfy)  += wy*uy;
+      k_field_scatter_access(iiy, field_var::jfz)  += wy*uz;
+      k_field_scatter_access(iiy, field_var::rhof) += wy;
+
+      k_field_scatter_access(iiz, field_var::jfx)  += wz*ux;
+      k_field_scatter_access(iiz, field_var::jfy)  += wz*uy;
+      k_field_scatter_access(iiz, field_var::jfz)  += wz*uz;
+      k_field_scatter_access(iiz, field_var::rhof) += wz;
+
+      k_field_scatter_access(iimx, field_var::jfx)  += wmx*ux;
+      k_field_scatter_access(iimx, field_var::jfy)  += wmx*uy;
+      k_field_scatter_access(iimx, field_var::jfz)  += wmx*uz;
+      k_field_scatter_access(iimx, field_var::rhof) += wmx;
+
+      k_field_scatter_access(iimy, field_var::jfx)  += wmy*ux;
+      k_field_scatter_access(iimy, field_var::jfy)  += wmy*uy;
+      k_field_scatter_access(iimy, field_var::jfz)  += wmy*uz;
+      k_field_scatter_access(iimy, field_var::rhof) += wmy;
+
+      k_field_scatter_access(iimz, field_var::jfx)  += wmz*ux;
+      k_field_scatter_access(iimz, field_var::jfy)  += wmz*uy;
+      k_field_scatter_access(iimz, field_var::jfz)  += wmz*uz;
+      k_field_scatter_access(iimz, field_var::rhof) += wmz;
+
+#endif
+#endif
     
 } else {
       
@@ -1051,6 +1170,49 @@ advance_p_kokkos_gpu(
   //args->seg[pipeline_rank].n_ignored = 0; // TODO: update this
   //delete(k_local_particle_movers_p);
   //return h_nm(0);
+
+  #undef f_ex
+  #undef f_dexdx
+  #undef f_dexdy
+  #undef f_dexdz
+  #undef f_d2exdx
+  #undef f_d2exdy
+  #undef f_d2exdz
+  #undef f_ey
+  #undef f_deydx
+  #undef f_deydy
+  #undef f_deydz
+  #undef f_d2eydx
+  #undef f_d2eydy
+  #undef f_d2eydz
+  #undef f_ez
+  #undef f_dezdx
+  #undef f_dezdy
+  #undef f_dezdz
+  #undef f_d2ezdx
+  #undef f_d2ezdy
+  #undef f_d2ezdz
+  #undef f_cbx
+  #undef f_dcbxdx
+  #undef f_dcbxdy
+  #undef f_dcbxdz
+  #undef f_d2cbxdx
+  #undef f_d2cbxdy
+  #undef f_d2cbxdz
+  #undef f_cby
+  #undef f_dcbydx
+  #undef f_dcbydy
+  #undef f_dcbydz
+  #undef f_d2cbydx
+  #undef f_d2cbydy
+  #undef f_d2cbydz
+  #undef f_cbz
+  #undef f_dcbzdx
+  #undef f_dcbzdy
+  #undef f_dcbzdz
+  #undef f_d2cbzdx
+  #undef f_d2cbzdy
+  #undef f_d2cbzdz
 
       } //advance_p_kokkos_gpu
 

--- a/src/species_advance/standard/advance_p.cc
+++ b/src/species_advance/standard/advance_p.cc
@@ -199,6 +199,8 @@ void unrolled_simd_load(float* vals, const int* ii, const k_interpolator_t& k_in
   }
 }
 
+#ifdef SHAPE_NGP
+
 // Load interpolators
 template<int NumLanes>
 KOKKOS_INLINE_FUNCTION
@@ -264,8 +266,226 @@ void load_interpolators(
     fcby[LANE]      = k_interp(ii[LANE], interpolator_var::cby);    
     fcbz[LANE]      = k_interp(ii[LANE], interpolator_var::cbz);    
   }
-#endif
-}
+#endif // defined(VPIC_ENABLE_VECTORIZATION) && !defined(USE_GPU)
+} // void load_interpolators(...) for SHAPE_NGP
+
+#else
+#ifdef SHAPE_QS
+
+// Load interpolators
+template<int NumLanes>
+KOKKOS_INLINE_FUNCTION
+void load_interpolators(
+                        float* fex,
+                        float* fdexdx,
+                        float* fdexdy,
+                        float* fdexdz,
+                        float* fd2exdx,
+                        float* fd2exdy,
+                        float* fd2exdz,
+                        float* fey,
+                        float* fdeydx,
+                        float* fdeydy,
+                        float* fdeydz,
+                        float* fd2eydx,
+                        float* fd2eydy,
+                        float* fd2eydz,
+                        float* fez,
+                        float* fdezdx,
+                        float* fdezdy,
+                        float* fdezdz,
+                        float* fd2ezdx,
+                        float* fd2ezdy,
+                        float* fd2ezdz,
+                        float* fcbx,
+                        float* fdcbxdx,
+                        float* fdcbxdy,
+                        float* fdcbxdz,
+                        float* fd2cbxdx,
+                        float* fd2cbxdy,
+                        float* fd2cbxdz,
+                        float* fcby,
+                        float* fdcbydx,
+                        float* fdcbydy,
+                        float* fdcbydz,
+                        float* fd2cbydx,
+                        float* fd2cbydy,
+                        float* fd2cbydz,
+                        float* fcbz,
+                        float* fdcbzdx,
+                        float* fdcbzdy,
+                        float* fdcbzdz,
+                        float* fd2cbzdx,
+                        float* fd2cbzdy,
+                        float* fd2cbzdz,
+                        const int* ii,
+                        const int num_part,
+                        const k_interpolator_t& k_interp
+                        ) {
+#if defined(VPIC_ENABLE_VECTORIZATION) && !defined(USE_GPU)
+  int same_cell = 1;
+  for(int lane=0; lane<NumLanes; lane++) {
+    if(ii[0] != ii[lane]) {
+      same_cell = 0;
+      break;
+    }
+  }
+
+  // Try to reduce the number of loads if all particles are in the same cell
+  if(same_cell) {
+    float vals[INTERPOLATOR_VAR_COUNT];
+
+    simd_load_interpolator_var(vals, ii[0], k_interp, INTERPOLATOR_VAR_COUNT);
+    #pragma omp simd
+    for(int i=0; i<NumLanes; i++) {
+      fex[i]      = vals[ 0];
+      fdexdx[i]   = vals[ 1];
+      fdexdy[i]   = vals[ 2];
+      fdexdz[i]   = vals[ 3];
+      fd2exdx[i]  = vals[ 4];
+      fd2exdy[i]  = vals[ 5];
+      fd2exdz[i]  = vals[ 6];
+      fey[i]      = vals[ 7];
+      fdeydx[i]   = vals[ 8];
+      fdeydy[i]   = vals[ 9];
+      fdeydz[i]   = vals[10];
+      fd2eydx[i]  = vals[11];
+      fd2eydy[i]  = vals[12];
+      fd2eydz[i]  = vals[13];
+      fez[i]      = vals[14];
+      fdezdx[i]   = vals[15];
+      fdezdy[i]   = vals[16];
+      fdezdz[i]   = vals[17];
+      fd2ezdx[i]  = vals[18];
+      fd2ezdy[i]  = vals[19];
+      fd2ezdz[i]  = vals[20];
+      fcbx[i]     = vals[21];
+      fdcbxdx[i]  = vals[22];
+      fdcbxdy[i]  = vals[23];
+      fdcbxdz[i]  = vals[24];
+      fd2cbxdx[i] = vals[25];
+      fd2cbxdy[i] = vals[26];
+      fd2cbxdz[i] = vals[27];
+      fcby[i]     = vals[28];
+      fdcbydx[i]  = vals[29];
+      fdcbydy[i]  = vals[30];
+      fdcbydz[i]  = vals[31];
+      fd2cbydx[i] = vals[32];
+      fd2cbydy[i] = vals[33];
+      fd2cbydz[i] = vals[34];
+      fcbz[i]     = vals[35];
+      fdcbzdx[i]  = vals[36];
+      fdcbzdy[i]  = vals[37];
+      fdcbzdz[i]  = vals[38];
+      fd2cbzdx[i] = vals[39];
+      fd2cbzdy[i] = vals[40];
+      fd2cbzdz[i] = vals[41];
+    }
+  } else {
+
+    // Efficient vectorized load
+    float vals[INTERPOLATOR_VAR_COUNT * NumLanes];
+    unrolled_simd_load(vals, ii, k_interp, INTERPOLATOR_VAR_COUNT, num_part);
+//    unrolled_simd_load<NumLanes>(vals, ii, k_interp, INTERPOLATOR_VAR_COUNT);
+
+    // Essentially a transpose
+    #pragma omp simd
+    for(int i=0; i<num_part; i++) {
+      fex[i]      = vals[ 0 + INTERPOLATOR_VAR_COUNT*i];
+      fdexdx[i]   = vals[ 1 + INTERPOLATOR_VAR_COUNT*i];
+      fdexdy[i]   = vals[ 2 + INTERPOLATOR_VAR_COUNT*i];
+      fdexdz[i]   = vals[ 3 + INTERPOLATOR_VAR_COUNT*i];
+      fd2exdx[i]  = vals[ 4 + INTERPOLATOR_VAR_COUNT*i];
+      fd2exdy[i]  = vals[ 5 + INTERPOLATOR_VAR_COUNT*i];
+      fd2exdz[i]  = vals[ 6 + INTERPOLATOR_VAR_COUNT*i];
+      fey[i]      = vals[ 7 + INTERPOLATOR_VAR_COUNT*i];
+      fdeydx[i]   = vals[ 8 + INTERPOLATOR_VAR_COUNT*i];
+      fdeydy[i]   = vals[ 9 + INTERPOLATOR_VAR_COUNT*i];
+      fdeydz[i]   = vals[10 + INTERPOLATOR_VAR_COUNT*i];
+      fd2eydx[i]  = vals[11 + INTERPOLATOR_VAR_COUNT*i];
+      fd2eydy[i]  = vals[12 + INTERPOLATOR_VAR_COUNT*i];
+      fd2eydz[i]  = vals[13 + INTERPOLATOR_VAR_COUNT*i];
+      fez[i]      = vals[14 + INTERPOLATOR_VAR_COUNT*i];
+      fdezdx[i]   = vals[15 + INTERPOLATOR_VAR_COUNT*i];
+      fdezdy[i]   = vals[16 + INTERPOLATOR_VAR_COUNT*i];
+      fdezdz[i]   = vals[17 + INTERPOLATOR_VAR_COUNT*i];
+      fd2ezdx[i]  = vals[18 + INTERPOLATOR_VAR_COUNT*i];
+      fd2ezdy[i]  = vals[19 + INTERPOLATOR_VAR_COUNT*i];
+      fd2ezdz[i]  = vals[20 + INTERPOLATOR_VAR_COUNT*i];
+      fcbx[i]     = vals[21 + INTERPOLATOR_VAR_COUNT*i];
+      fdcbxdx[i]  = vals[22 + INTERPOLATOR_VAR_COUNT*i];
+      fdcbxdy[i]  = vals[23 + INTERPOLATOR_VAR_COUNT*i];
+      fdcbxdz[i]  = vals[24 + INTERPOLATOR_VAR_COUNT*i];
+      fd2cbxdx[i] = vals[25 + INTERPOLATOR_VAR_COUNT*i];
+      fd2cbxdy[i] = vals[26 + INTERPOLATOR_VAR_COUNT*i];
+      fd2cbxdz[i] = vals[27 + INTERPOLATOR_VAR_COUNT*i];
+      fcby[i]     = vals[28 + INTERPOLATOR_VAR_COUNT*i];
+      fdcbydx[i]  = vals[29 + INTERPOLATOR_VAR_COUNT*i];
+      fdcbydy[i]  = vals[30 + INTERPOLATOR_VAR_COUNT*i];
+      fdcbydz[i]  = vals[31 + INTERPOLATOR_VAR_COUNT*i];
+      fd2cbydx[i] = vals[32 + INTERPOLATOR_VAR_COUNT*i];
+      fd2cbydy[i] = vals[33 + INTERPOLATOR_VAR_COUNT*i];
+      fd2cbydz[i] = vals[34 + INTERPOLATOR_VAR_COUNT*i];
+      fcbz[i]     = vals[35 + INTERPOLATOR_VAR_COUNT*i];
+      fdcbzdx[i]  = vals[36 + INTERPOLATOR_VAR_COUNT*i];
+      fdcbzdy[i]  = vals[37 + INTERPOLATOR_VAR_COUNT*i];
+      fdcbzdz[i]  = vals[38 + INTERPOLATOR_VAR_COUNT*i];
+      fd2cbzdx[i] = vals[39 + INTERPOLATOR_VAR_COUNT*i];
+      fd2cbzdy[i] = vals[40 + INTERPOLATOR_VAR_COUNT*i];
+      fd2cbzdz[i] = vals[41 + INTERPOLATOR_VAR_COUNT*i];
+    }
+  }
+#else
+  for(int lane=0; lane<NumLanes; lane++) {
+    // Load interpolators
+    fex[LANE]      = k_interp(ii[LANE], interpolator_var::ex);
+    fdexdx[LANE]   = k_interp(ii[LANE], interpolator_var::dexdx);
+    fdexdy[LANE]   = k_interp(ii[LANE], interpolator_var::dexdy);
+    fdexdz[LANE]   = k_interp(ii[LANE], interpolator_var::dexdz);
+    fd2exdx[LANE]  = k_interp(ii[LANE], interpolator_var::d2exdx);
+    fd2exdy[LANE]  = k_interp(ii[LANE], interpolator_var::d2exdy);
+    fd2exdz[LANE]  = k_interp(ii[LANE], interpolator_var::d2exdz);
+    fey[LANE]      = k_interp(ii[LANE], interpolator_var::ey);
+    fdeydx[LANE]   = k_interp(ii[LANE], interpolator_var::deydx);
+    fdeydy[LANE]   = k_interp(ii[LANE], interpolator_var::deydy);
+    fdeydz[LANE]   = k_interp(ii[LANE], interpolator_var::deydz);
+    fd2eydx[LANE]  = k_interp(ii[LANE], interpolator_var::d2eydx);
+    fd2eydy[LANE]  = k_interp(ii[LANE], interpolator_var::d2eydy);
+    fd2eydz[LANE]  = k_interp(ii[LANE], interpolator_var::d2eydz);
+    fez[LANE]      = k_interp(ii[LANE], interpolator_var::ez);
+    fdezdx[LANE]   = k_interp(ii[LANE], interpolator_var::dezdx);
+    fdezdy[LANE]   = k_interp(ii[LANE], interpolator_var::dezdy);
+    fdezdz[LANE]   = k_interp(ii[LANE], interpolator_var::dezdz);
+    fd2ezdx[LANE]  = k_interp(ii[LANE], interpolator_var::d2ezdx);
+    fd2ezdy[LANE]  = k_interp(ii[LANE], interpolator_var::d2ezdy);
+    fd2ezdz[LANE]  = k_interp(ii[LANE], interpolator_var::d2ezdz);
+    fcbx[LANE]     = k_interp(ii[LANE], interpolator_var::cbx);
+    fdcbxdx[LANE]  = k_interp(ii[LANE], interpolator_var::dcbxdx);
+    fdcbxdy[LANE]  = k_interp(ii[LANE], interpolator_var::dcbxdy);
+    fdcbxdz[LANE]  = k_interp(ii[LANE], interpolator_var::dcbxdz);
+    fd2cbxdx[LANE] = k_interp(ii[LANE], interpolator_var::d2cbxdx);
+    fd2cbxdy[LANE] = k_interp(ii[LANE], interpolator_var::d2cbxdy);
+    fd2cbxdz[LANE] = k_interp(ii[LANE], interpolator_var::d2cbxdz);
+    fcby[LANE]     = k_interp(ii[LANE], interpolator_var::cby);
+    fdcbydx[LANE]  = k_interp(ii[LANE], interpolator_var::dcbydx);
+    fdcbydy[LANE]  = k_interp(ii[LANE], interpolator_var::dcbydy);
+    fdcbydz[LANE]  = k_interp(ii[LANE], interpolator_var::dcbydz);
+    fd2cbydx[LANE] = k_interp(ii[LANE], interpolator_var::d2cbydx);
+    fd2cbydy[LANE] = k_interp(ii[LANE], interpolator_var::d2cbydy);
+    fd2cbydz[LANE] = k_interp(ii[LANE], interpolator_var::d2cbydz);
+    fcbz[LANE]     = k_interp(ii[LANE], interpolator_var::cbz);
+    fdcbzdx[LANE]  = k_interp(ii[LANE], interpolator_var::dcbzdx);
+    fdcbzdy[LANE]  = k_interp(ii[LANE], interpolator_var::dcbzdy);
+    fdcbzdz[LANE]  = k_interp(ii[LANE], interpolator_var::dcbzdz);
+    fd2cbzdx[LANE] = k_interp(ii[LANE], interpolator_var::d2cbzdx);
+    fd2cbzdy[LANE] = k_interp(ii[LANE], interpolator_var::d2cbzdy);
+    fd2cbzdz[LANE] = k_interp(ii[LANE], interpolator_var::d2cbzdz);
+  }
+#endif // defined(VPIC_ENABLE_VECTORIZATION) && !defined(USE_GPU)
+} // void load_interpolators(...) for SHAPE_QS
+
+#endif // defined(SHAPE_QS)
+#endif // defined(SHAPE_NGP)
 
 void
 advance_p_kokkos_unified(
@@ -298,6 +518,8 @@ advance_p_kokkos_unified(
         const int nz)
 {
 
+  constexpr float three          = 3.;
+  constexpr float two            = 2.;
   constexpr float one            = 1.;
   constexpr float one_third      = 1./3.;
   constexpr float two_fifteenths = 2./15.;
@@ -320,29 +542,6 @@ advance_p_kokkos_unified(
   #define p_q     k_particles(p_index, particle_var::qp)
 #endif
   #define pii     k_particles_i(p_index)
-
-  #define f_cbx k_interp(ii[LANE], interpolator_var::cbx)
-  #define f_cby k_interp(ii[LANE], interpolator_var::cby)
-  #define f_cbz k_interp(ii[LANE], interpolator_var::cbz)
-  #define f_ex  k_interp(ii[LANE], interpolator_var::ex)
-  #define f_ey  k_interp(ii[LANE], interpolator_var::ey)
-  #define f_ez  k_interp(ii[LANE], interpolator_var::ez)
-
-  #define f_dexdy    k_interp(ii[LANE], interpolator_var::dexdy)
-  #define f_dexdz    k_interp(ii[LANE], interpolator_var::dexdz)
-
-  #define f_d2exdydz k_interp(ii[LANE], interpolator_var::d2exdydz)
-  #define f_deydx    k_interp(ii[LANE], interpolator_var::deydx)
-  #define f_deydz    k_interp(ii[LANE], interpolator_var::deydz)
-
-  #define f_d2eydzdx k_interp(ii[LANE], interpolator_var::d2eydzdx)
-  #define f_dezdx    k_interp(ii[LANE], interpolator_var::dezdx)
-  #define f_dezdy    k_interp(ii[LANE], interpolator_var::dezdy)
-
-  #define f_d2ezdxdy k_interp(ii[LANE], interpolator_var::d2ezdxdy)
-  #define f_dcbxdx   k_interp(ii[LANE], interpolator_var::dcbxdx)
-  #define f_dcbydy   k_interp(ii[LANE], interpolator_var::dcbydy)
-  #define f_dcbzdz   k_interp(ii[LANE], interpolator_var::dcbzdz)
 
   auto rangel = g->rangel;
   auto rangeh = g->rangeh;
@@ -428,7 +627,7 @@ advance_p_kokkos_unified(
       int   inbnds[num_lanes];
       //int   midbnds[num_lanes];
 
-
+#ifdef SHAPE_NGP
       float fcbx[num_lanes];
       float fcby[num_lanes];
       float fcbz[num_lanes];
@@ -445,6 +644,60 @@ advance_p_kokkos_unified(
       float *v11 = fcbz;
       float *v12 = tmp0;
       float *v13 = tmp1;
+#else
+#ifdef SHAPE_QS
+      float fex[num_lanes];
+      float fdexdx[num_lanes];
+      float fdexdy[num_lanes];
+      float fdexdz[num_lanes];
+      float fd2exdx[num_lanes];
+      float fd2exdy[num_lanes];
+      float fd2exdz[num_lanes];
+      float fey[num_lanes];
+      float fdeydx[num_lanes];
+      float fdeydy[num_lanes];
+      float fdeydz[num_lanes];
+      float fd2eydx[num_lanes];
+      float fd2eydy[num_lanes];
+      float fd2eydz[num_lanes];
+      float fez[num_lanes];
+      float fdezdx[num_lanes];
+      float fdezdy[num_lanes];
+      float fdezdz[num_lanes];
+      float fd2ezdx[num_lanes];
+      float fd2ezdy[num_lanes];
+      float fd2ezdz[num_lanes];
+      float fcbx[num_lanes];
+      float fdcbxdx[num_lanes];
+      float fdcbxdy[num_lanes];
+      float fdcbxdz[num_lanes];
+      float fd2cbxdx[num_lanes];
+      float fd2cbxdy[num_lanes];
+      float fd2cbxdz[num_lanes];
+      float fcby[num_lanes];
+      float fdcbydx[num_lanes];
+      float fdcbydy[num_lanes];
+      float fdcbydz[num_lanes];
+      float fd2cbydx[num_lanes];
+      float fd2cbydy[num_lanes];
+      float fd2cbydz[num_lanes];
+      float fcbz[num_lanes];
+      float fdcbzdx[num_lanes];
+      float fdcbzdy[num_lanes];
+      float fdcbzdz[num_lanes];
+      float fd2cbzdx[num_lanes];
+      float fd2cbzdy[num_lanes];
+      float fd2cbzdz[num_lanes];
+      float *v6 = fex;
+      float *v7 = fdexdx;
+      float *v8 = fdexdy;
+      float *v9 = fdexdz;
+      float *v10 = fey;
+      float *v11 = fdeydx;
+      float *v12 = fdeydy;
+      float *v13 = fdeydz;
+#endif // defined(SHAPE_QS)
+#endif // defined(SHAPE_NGP)
 
       size_t p_index = pi_offset;
 
@@ -468,16 +721,29 @@ advance_p_kokkos_unified(
         ii[LANE] = pii;
       } END_VECTOR_BLOCK;
 
+#ifdef SHAPE_NGP
       load_interpolators<num_lanes>( fex, fey, fez, fcbx, fcby, fcbz,
                                      ii, num_particles, k_interp);
+#else
+#ifdef SHAPE_QS
+      load_interpolators<num_lanes>( fex, fdexdx, fdexdy, fdexdz, fd2exdx, fd2exdy, fd2exdz,
+                                     fey, fdeydx, fdeydy, fdeydz, fd2eydx, fd2eydy, fd2eydz,
+                                     fez, fdezdx, fdezdy, fdezdz, fd2ezdx, fd2ezdy, fd2ezdz,
+                                     fcbx, fdcbxdx, fdcbxdy, fdcbxdz, fd2cbxdx, fd2cbxdy, fd2cbxdz,
+                                     fcby, fdcbydx, fdcbydy, fdcbydz, fd2cbydx, fd2cbydy, fd2cbydz,
+                                     fcbz, fdcbzdx, fdcbzdy, fdcbzdz, fd2cbzdx, fd2cbzdy, fd2cbzdz,
+                                     ii, num_particles, k_interp);
+#endif // defined(SHAPE_QS)
+#endif // defined(SHAPE_NGP)
 
       BEGIN_VECTOR_BLOCK {
-#ifdef VARIABLE_CHARGE
-	hax[LANE] = dt_2mc*qp[LANE]*( (fex[LANE] ) );
-	hay[LANE] = dt_2mc*qp[LANE]*( (fey[LANE] ) );
-	haz[LANE] = dt_2mc*qp[LANE]*( (fez[LANE] ) );
-#else
+#ifdef SHAPE_NGP
         // Interpolate E
+#ifdef VARIABLE_CHARGE
+        hax[LANE] = dt_2mc*qp[LANE]*( (fex[LANE] ) );
+        hay[LANE] = dt_2mc*qp[LANE]*( (fey[LANE] ) );
+        haz[LANE] = dt_2mc*qp[LANE]*( (fez[LANE] ) );
+#else
         hax[LANE] = qdt_2mc*( (fex[LANE] ) );
         hay[LANE] = qdt_2mc*( (fey[LANE] ) );
         haz[LANE] = qdt_2mc*( (fez[LANE] ) );
@@ -486,6 +752,45 @@ advance_p_kokkos_unified(
         cbx[LANE] = fcbx[LANE];// + dx[LANE]*fdcbxdx[LANE];
         cby[LANE] = fcby[LANE];// + dy[LANE]*fdcbydy[LANE];
         cbz[LANE] = fcbz[LANE];// + dz[LANE]*fdcbzdz[LANE];
+#else
+#ifdef SHAPE_QS
+        // Interpolate E
+#ifdef VARIABLE_CHARGE
+        hax[LANE]  = dt_2mc*qp[LANE]*( fex[LANE]
+                        + dx[LANE]*( fdexdx[LANE] + dx[LANE]*fd2exdx[LANE] )
+                        + dy[LANE]*( fdexdy[LANE] + dy[LANE]*fd2exdy[LANE] )
+                        + dz[LANE]*( fdexdz[LANE] + dz[LANE]*fd2exdz[LANE] ) );
+        hay[LANE]  = dt_2mc*qp[LANE]*( fey[LANE]
+                        + dx[LANE]*( fdeydx[LANE] + dx[LANE]*fd2eydx[LANE] )
+                        + dy[LANE]*( fdeydy[LANE] + dy[LANE]*fd2eydy[LANE] )
+                        + dz[LANE]*( fdeydz[LANE] + dz[LANE]*fd2eydz[LANE] ) );
+        haz[LANE]  = dt_2mc*qp[LANE]*( fez[LANE]
+                        + dx[LANE]*( fdezdx[LANE] + dx[LANE]*fd2ezdx[LANE] )
+                        + dy[LANE]*( fdezdy[LANE] + dy[LANE]*fd2ezdy[LANE] )
+                        + dz[LANE]*( fdezdz[LANE] + dz[LANE]*fd2ezdz[LANE] ) );
+#else
+        hax[LANE]  = qdt_2mc*( fex[LANE] + dx[LANE]*( fdexdx[LANE] + dx[LANE]*fd2exdx[LANE] )
+                                         + dy[LANE]*( fdexdy[LANE] + dy[LANE]*fd2exdy[LANE] )
+                                         + dz[LANE]*( fdexdz[LANE] + dz[LANE]*fd2exdz[LANE] ) );
+        hay[LANE]  = qdt_2mc*( fey[LANE] + dx[LANE]*( fdeydx[LANE] + dx[LANE]*fd2eydx[LANE] )
+                                         + dy[LANE]*( fdeydy[LANE] + dy[LANE]*fd2eydy[LANE] )
+                                         + dz[LANE]*( fdeydz[LANE] + dz[LANE]*fd2eydz[LANE] ) );
+        haz[LANE]  = qdt_2mc*( fez[LANE] + dx[LANE]*( fdezdx[LANE] + dx[LANE]*fd2ezdx[LANE] )
+                                         + dy[LANE]*( fdezdy[LANE] + dy[LANE]*fd2ezdy[LANE] )
+                                         + dz[LANE]*( fdezdz[LANE] + dz[LANE]*fd2ezdz[LANE] ) );
+#endif
+        // Interpolate B
+        cbx[LANE]  = fcbx[LANE] + dx[LANE]*( fdcbxdx[LANE] + dx[LANE]*fd2cbxdx[LANE] )
+                                + dy[LANE]*( fdcbxdy[LANE] + dy[LANE]*fd2cbxdy[LANE] )
+                                + dz[LANE]*( fdcbxdz[LANE] + dz[LANE]*fd2cbxdz[LANE] );
+        cby[LANE]  = fcby[LANE] + dx[LANE]*( fdcbydx[LANE] + dx[LANE]*fd2cbydx[LANE] )
+                                + dy[LANE]*( fdcbydy[LANE] + dy[LANE]*fd2cbydy[LANE] )
+                                + dz[LANE]*( fdcbydz[LANE] + dz[LANE]*fd2cbydz[LANE] );
+        cbz[LANE]  = fcbz[LANE] + dx[LANE]*( fdcbzdx[LANE] + dx[LANE]*fd2cbzdx[LANE] )
+                                + dy[LANE]*( fdcbzdy[LANE] + dy[LANE]*fd2cbzdy[LANE] )
+                                + dz[LANE]*( fdcbzdz[LANE] + dz[LANE]*fd2cbzdz[LANE] );
+#endif // defined(SHAPE_QS)
+#endif // defined(SHAPE_NGP)
   
         // Half advance e
         ux[LANE] += hax[LANE];
@@ -704,29 +1009,6 @@ advance_p_kokkos_unified(
 #endif
   
 #undef pii 
-
-#undef f_cbx
-#undef f_cby
-#undef f_cbz
-#undef f_ex 
-#undef f_ey 
-#undef f_ez 
-
-#undef f_dexdy
-#undef f_dexdz
-
-#undef f_d2exdydz
-#undef f_deydx   
-#undef f_deydz   
-
-#undef f_d2eydzdx
-#undef f_dezdx   
-#undef f_dezdy   
-
-#undef f_d2ezdxdy
-#undef f_dcbxdx  
-#undef f_dcbydy  
-#undef f_dcbzdz  
 		       }
 
 void

--- a/src/species_advance/standard/center_p.cc
+++ b/src/species_advance/standard/center_p.cc
@@ -48,14 +48,13 @@ center_p_pipeline( center_p_pipeline_args_t * args,
     ii   = p->i;
     f    = f0 + ii;                             // Load interpolator
 #ifdef SHAPE_NGP
-    hax  = qdt_2mc*(    ( f->ex     ) );        // Interpolate E
-    hay  = qdt_2mc*(    ( f->ey     ) );
-    haz  = qdt_2mc*(    ( f->ez     ) );
-    cbx  = f->cbx;// + dx*f->dcbxdx;            // Interpolate B
-    cby  = f->cby;// + dy*f->dcbydy;
-    cbz  = f->cbz;// + dz*f->dcbzdz;
-#else
-#ifdef SHAPE_QS
+    hax  = qdt_2mc*( f->ex );        // Interpolate E
+    hay  = qdt_2mc*( f->ey );
+    haz  = qdt_2mc*( f->ez );
+    cbx  = f->cbx;            // Interpolate B
+    cby  = f->cby;
+    cbz  = f->cbz;
+#elif defined( SHAPE_QS )
     hax  = qdt_2mc*( f->ex + dx*( f->dexdx + dx*f->d2exdx )   // Interpolate E
                            + dy*( f->dexdy + dy*f->d2exdy )
                            + dz*( f->dexdz + dz*f->d2exdz ) );
@@ -74,7 +73,6 @@ center_p_pipeline( center_p_pipeline_args_t * args,
     cbz  = f->cbz + dx*( f->dcbzdx + dx*f->d2cbzdx )
                   + dy*( f->dcbzdy + dy*f->d2cbzdy )
                   + dz*( f->dcbzdz + dz*f->d2cbzdz );
-#endif
 #endif
     ux   = p->ux;                            // Load momentum
     uy   = p->uy;

--- a/src/species_advance/standard/center_p.cc
+++ b/src/species_advance/standard/center_p.cc
@@ -46,13 +46,36 @@ center_p_pipeline( center_p_pipeline_args_t * args,
     qdt_4mc = 0.5*qdt_2mc;
 #endif
     ii   = p->i;
-    f    = f0 + ii;                          // Interpolate E
-    hax  = qdt_2mc*(    ( f->ex     ) );
+    f    = f0 + ii;                             // Load interpolator
+#ifdef SHAPE_NGP
+    hax  = qdt_2mc*(    ( f->ex     ) );        // Interpolate E
     hay  = qdt_2mc*(    ( f->ey     ) );
     haz  = qdt_2mc*(    ( f->ez     ) );
     cbx  = f->cbx;// + dx*f->dcbxdx;            // Interpolate B
     cby  = f->cby;// + dy*f->dcbydy;
     cbz  = f->cbz;// + dz*f->dcbzdz;
+#else
+#ifdef SHAPE_QS
+    hax  = qdt_2mc*( f->ex + dx*( f->dexdx + dx*f->d2exdx )   // Interpolate E
+                           + dy*( f->dexdy + dy*f->d2exdy )
+                           + dz*( f->dexdz + dz*f->d2exdz ) );
+    hay  = qdt_2mc*( f->ey + dx*( f->deydx + dx*f->d2eydx )
+                           + dy*( f->deydy + dy*f->d2eydy )
+                           + dz*( f->deydz + dz*f->d2eydz ) );
+    haz  = qdt_2mc*( f->ez + dx*( f->dezdx + dx*f->d2ezdx )
+                           + dy*( f->dezdy + dy*f->d2ezdy )
+                           + dz*( f->dezdz + dz*f->d2ezdz ) );
+    cbx  = f->cbx + dx*( f->dcbxdx + dx*f->d2cbxdx )          // Interpolate B
+                  + dy*( f->dcbxdy + dy*f->d2cbxdy )
+                  + dz*( f->dcbxdz + dz*f->d2cbxdz );
+    cby  = f->cby + dx*( f->dcbydx + dx*f->d2cbydx )
+                  + dy*( f->dcbydy + dy*f->d2cbydy )
+                  + dz*( f->dcbydz + dz*f->d2cbydz );
+    cbz  = f->cbz + dx*( f->dcbzdx + dx*f->d2cbzdx )
+                  + dy*( f->dcbzdy + dy*f->d2cbzdy )
+                  + dz*( f->dcbzdz + dz*f->d2cbzdz );
+#endif
+#endif
     ux   = p->ux;                            // Load momentum
     uy   = p->uy;
     uz   = p->uz;

--- a/src/species_advance/standard/energy_p.cc
+++ b/src/species_advance/standard/energy_p.cc
@@ -35,8 +35,7 @@ energy_p_pipeline( energy_p_pipeline_args_t * RESTRICT args,
     v0  = p[n].ux + qdt_2mc * f[i].ex;
     v1  = p[n].uy + qdt_2mc * f[i].ey;
     v2  = p[n].uz + qdt_2mc * f[i].ez;
-#else
-#ifdef SHAPE_QS
+#elif defined( SHAPE_QS )
     v0 = p[n].ux + qdt_2mc*( f[i].ex + dx*( f[i].dexdx + dx*f[i].d2exdx )
                                      + dy*( f[i].dexdy + dy*f[i].d2exdy )
                                      + dz*( f[i].dexdz + dz*f[i].d2exdz ) );
@@ -46,7 +45,6 @@ energy_p_pipeline( energy_p_pipeline_args_t * RESTRICT args,
     v2 = p[n].uz + qdt_2mc*( f[i].ez + dx*( f[i].dezdx + dx*f[i].d2ezdx )
                                      + dy*( f[i].dezdy + dy*f[i].d2ezdy )
                                      + dz*( f[i].dezdz + dz*f[i].d2ezdz ) );
-#endif
 #endif
     v0  = v0*v0 + v1*v1 + v2*v2;
     v0  = (msp * p[n].w) * (v0 / (one + sqrtf(one + v0)));
@@ -203,8 +201,7 @@ energy_p_kernel(const k_interpolator_t& k_interp, const k_particles_t& k_particl
         float v0 = ux + qdt_2mc * f_ex;
         float v1 = uy + qdt_2mc * f_ey;
         float v2 = uz + qdt_2mc * f_ez;
-#else
-#ifdef SHAPE_QS
+#elif defined( SHAPE_QS )
         // Interpolate E
         float v0 = ux + qdt_2mc*( f_ex + dx*( f_dexdx + dx*f_d2exdx )
                                        + dy*( f_dexdy + dy*f_d2exdy )
@@ -215,7 +212,6 @@ energy_p_kernel(const k_interpolator_t& k_interp, const k_particles_t& k_particl
         float v2 = uz + qdt_2mc*( f_ez + dx*( f_dezdx + dx*f_d2ezdx )
                                        + dy*( f_dezdy + dy*f_d2ezdy )
                                        + dz*( f_dezdz + dz*f_d2ezdz ) );
-#endif
 #endif
         v0 = v0*v0 + v1*v1 + v2*v2;
         //v0 = (msp * k_particles(n, particle_var::w)) * (v0 / (1 + sqrtf(1 + v0)));  // Relativistic kinetic energy

--- a/src/species_advance/standard/energy_p.cc
+++ b/src/species_advance/standard/energy_p.cc
@@ -31,12 +31,23 @@ energy_p_pipeline( energy_p_pipeline_args_t * RESTRICT args,
     dy  = p[n].dy;
     dz  = p[n].dz;
     i   = p[n].i;
-    v0  = p[n].ux + qdt_2mc*(    ( f[i].ex    + dy*f[i].dexdy    ) +
-                              dz*( f[i].dexdz + dy*f[i].d2exdydz ) );
-    v1  = p[n].uy + qdt_2mc*(    ( f[i].ey    + dz*f[i].deydz    ) +
-                              dx*( f[i].deydx + dz*f[i].d2eydzdx ) );
-    v2  = p[n].uz + qdt_2mc*(    ( f[i].ez    + dx*f[i].dezdx    ) +
-                              dy*( f[i].dezdy + dx*f[i].d2ezdxdy ) );
+#ifdef SHAPE_NGP
+    v0  = p[n].ux + qdt_2mc * f[i].ex;
+    v1  = p[n].uy + qdt_2mc * f[i].ey;
+    v2  = p[n].uz + qdt_2mc * f[i].ez;
+#else
+#ifdef SHAPE_QS
+    v0 = p[n].ux + qdt_2mc*( f[i].ex + dx*( f[i].dexdx + dx*f[i].d2exdx )
+                                     + dy*( f[i].dexdy + dy*f[i].d2exdy )
+                                     + dz*( f[i].dexdz + dz*f[i].d2exdz ) );
+    v1 = p[n].uy + qdt_2mc*( f[i].ey + dx*( f[i].deydx + dx*f[i].d2eydx )
+                                     + dy*( f[i].deydy + dy*f[i].d2eydy )
+                                     + dz*( f[i].deydz + dz*f[i].d2eydz ) );
+    v2 = p[n].uz + qdt_2mc*( f[i].ez + dx*( f[i].dezdx + dx*f[i].d2ezdx )
+                                     + dy*( f[i].dezdy + dy*f[i].d2ezdy )
+                                     + dz*( f[i].dezdz + dz*f[i].d2ezdz ) );
+#endif
+#endif
     v0  = v0*v0 + v1*v1 + v2*v2;
     v0  = (msp * p[n].w) * (v0 / (one + sqrtf(one + v0)));
     en += (double)v0;
@@ -157,24 +168,84 @@ energy_p_kernel(const k_interpolator_t& k_interp, const k_particles_t& k_particl
     en += (double)v0;
   }
 */
+
+    #define f_ex       k_interp(ii, interpolator_var::ex)
+    #define f_dexdx    k_interp(ii, interpolator_var::dexdx)
+    #define f_dexdy    k_interp(ii, interpolator_var::dexdy)
+    #define f_dexdz    k_interp(ii, interpolator_var::dexdz)
+    #define f_d2exdx   k_interp(ii, interpolator_var::d2exdx)
+    #define f_d2exdy   k_interp(ii, interpolator_var::d2exdy)
+    #define f_d2exdz   k_interp(ii, interpolator_var::d2exdz)
+    #define f_ey       k_interp(ii, interpolator_var::ey)
+    #define f_deydx    k_interp(ii, interpolator_var::deydx)
+    #define f_deydy    k_interp(ii, interpolator_var::deydy)
+    #define f_deydz    k_interp(ii, interpolator_var::deydz)
+    #define f_d2eydx   k_interp(ii, interpolator_var::d2eydx)
+    #define f_d2eydy   k_interp(ii, interpolator_var::d2eydy)
+    #define f_d2eydz   k_interp(ii, interpolator_var::d2eydz)
+    #define f_ez       k_interp(ii, interpolator_var::ez)
+    #define f_dezdx    k_interp(ii, interpolator_var::dezdx)
+    #define f_dezdy    k_interp(ii, interpolator_var::dezdy)
+    #define f_dezdz    k_interp(ii, interpolator_var::dezdz)
+    #define f_d2ezdx   k_interp(ii, interpolator_var::d2ezdx)
+    #define f_d2ezdy   k_interp(ii, interpolator_var::d2ezdy)
+    #define f_d2ezdz   k_interp(ii, interpolator_var::d2ezdz)
+
     Kokkos::parallel_reduce(np, KOKKOS_LAMBDA(const int n, double& update) {
+        float ux = k_particles(n, particle_var::dx);
+        float uy = k_particles(n, particle_var::dy);
+        float uz = k_particles(n, particle_var::dz);
         float dx = k_particles(n, particle_var::dx);
         float dy = k_particles(n, particle_var::dy);
         float dz = k_particles(n, particle_var::dz);
-        int   i  = k_particles_i(n);
-        float v0 = k_particles(n, particle_var::ux) + qdt_2mc*(    ( k_interp(i, interpolator_var::ex)    + dy*k_interp(i, interpolator_var::dexdy)    ) +
-                                dz*( k_interp(i, interpolator_var::dexdz) + dy*k_interp(i, interpolator_var::d2exdydz) ) );
-        float v1 = k_particles(n, particle_var::uy) + qdt_2mc*(    ( k_interp(i, interpolator_var::ey)    + dz*k_interp(i, interpolator_var::deydz)    ) +
-                                dx*( k_interp(i, interpolator_var::deydx) + dz*k_interp(i, interpolator_var::d2eydzdx) ) );
-        float v2 = k_particles(n, particle_var::uz) + qdt_2mc*(    ( k_interp(i, interpolator_var::ez)    + dx*k_interp(i, interpolator_var::dezdx)    ) +
-                                dy*( k_interp(i, interpolator_var::dezdy) + dx*k_interp(i, interpolator_var::d2ezdxdy) ) );
+        int   ii = k_particles_i(n);
+#ifdef SHAPE_NGP
+        float v0 = ux + qdt_2mc * f_ex;
+        float v1 = uy + qdt_2mc * f_ey;
+        float v2 = uz + qdt_2mc * f_ez;
+#else
+#ifdef SHAPE_QS
+        // Interpolate E
+        float v0 = ux + qdt_2mc*( f_ex + dx*( f_dexdx + dx*f_d2exdx )
+                                       + dy*( f_dexdy + dy*f_d2exdy )
+                                       + dz*( f_dexdz + dz*f_d2exdz ) );
+        float v1 = uy + qdt_2mc*( f_ey + dx*( f_deydx + dx*f_d2eydx )
+                                       + dy*( f_deydy + dy*f_d2eydy )
+                                       + dz*( f_deydz + dz*f_d2eydz ) );
+        float v2 = uz + qdt_2mc*( f_ez + dx*( f_dezdx + dx*f_d2ezdx )
+                                       + dy*( f_dezdy + dy*f_d2ezdy )
+                                       + dz*( f_dezdz + dz*f_d2ezdz ) );
+#endif
+#endif
         v0 = v0*v0 + v1*v1 + v2*v2;
         //v0 = (msp * k_particles(n, particle_var::w)) * (v0 / (1 + sqrtf(1 + v0)));  // Relativistic kinetic energy
         v0 *= 0.5 * (msp * k_particles(n, particle_var::w));  // Non-relativistic kinetic energy
         update += static_cast<double>(v0);
     }, en);
     return en;
-}
+
+    #undef f_ex
+    #undef f_dexdx
+    #undef f_dexdy
+    #undef f_dexdz
+    #undef f_d2exdx
+    #undef f_d2exdy
+    #undef f_d2exdz
+    #undef f_ey
+    #undef f_deydx
+    #undef f_deydy
+    #undef f_deydz
+    #undef f_d2eydx
+    #undef f_d2eydy
+    #undef f_d2eydz
+    #undef f_ez
+    #undef f_dezdx
+    #undef f_dezdy
+    #undef f_dezdz
+    #undef f_d2ezdx
+    #undef f_d2ezdy
+    #undef f_d2ezdz
+} // energy_p_kernel(...)
 
 double
 energy_p( const species_t            * RESTRICT sp,

--- a/src/species_advance/standard/energy_p.cc
+++ b/src/species_advance/standard/energy_p.cc
@@ -192,9 +192,9 @@ energy_p_kernel(const k_interpolator_t& k_interp, const k_particles_t& k_particl
     #define f_d2ezdz   k_interp(ii, interpolator_var::d2ezdz)
 
     Kokkos::parallel_reduce(np, KOKKOS_LAMBDA(const int n, double& update) {
-        float ux = k_particles(n, particle_var::dx);
-        float uy = k_particles(n, particle_var::dy);
-        float uz = k_particles(n, particle_var::dz);
+        float ux = k_particles(n, particle_var::ux);
+        float uy = k_particles(n, particle_var::uy);
+        float uz = k_particles(n, particle_var::uz);
         float dx = k_particles(n, particle_var::dx);
         float dy = k_particles(n, particle_var::dy);
         float dz = k_particles(n, particle_var::dz);

--- a/src/species_advance/standard/hydro_p.cc
+++ b/src/species_advance/standard/hydro_p.cc
@@ -73,15 +73,39 @@ accumulate_hydro_p( hydro_array_t              * RESTRICT ha,
     uz = p[n].uz;
     w  = p[n].w;
 
+#ifdef SHAPE_NGP
     // Half advance E
-    ux += qdt_2mc*((f[i].ex)); //+dy*f[i].dexdy) + dz*(f[i].dexdz+dy*f[i].d2exdydz));
-    uy += qdt_2mc*((f[i].ey)); //+dz*f[i].deydz) + dx*(f[i].deydx+dz*f[i].d2eydzdx));
-    uz += qdt_2mc*((f[i].ez)); //+dx*f[i].dezdx) + dy*(f[i].dezdy+dx*f[i].d2ezdxdy));
-
+    ux += qdt_2mc*f[i].ex;
+    uy += qdt_2mc*f[i].ey;
+    uz += qdt_2mc*f[i].ez;
     // Boris rotation - Interpolate B field
-    w5 = f[i].cbx; // + dx*f[i].dcbxdx;
-    w6 = f[i].cby; // + dy*f[i].dcbydy;
-    w7 = f[i].cbz; // + dz*f[i].dcbzdz;
+    w5 = f[i].cbx;
+    w6 = f[i].cby;
+    w7 = f[i].cbz;
+#else
+#ifdef SHAPE_QS
+    // Half advance E
+    ux += qdt_2mc*( f[i].ex + dx*( f[i].dexdx + dx*f[i].d2exdx )
+                            + dy*( f[i].dexdy + dy*f[i].d2exdy )
+                            + dz*( f[i].dexdz + dz*f[i].d2exdz ) );
+    uy += qdt_2mc*( f[i].ey + dx*( f[i].deydx + dx*f[i].d2eydx )
+                            + dy*( f[i].deydy + dy*f[i].d2eydy )
+                            + dz*( f[i].deydz + dz*f[i].d2eydz ) );
+    uz += qdt_2mc*( f[i].ez + dx*( f[i].dezdx + dx*f[i].d2ezdx )
+                            + dy*( f[i].dezdy + dy*f[i].d2ezdy )
+                            + dz*( f[i].dezdz + dz*f[i].d2ezdz ) );
+    // Boris rotation - Interpolate B field
+    w5 = f[i].cbx + dx*( f[i].dcbxdx + dx*f[i].d2cbxdx )
+                  + dy*( f[i].dcbxdy + dy*f[i].d2cbxdy )
+                  + dz*( f[i].dcbxdz + dz*f[i].d2cbxdz );
+    w6 = f[i].cby + dx*( f[i].dcbydx + dx*f[i].d2cbydx )
+                  + dy*( f[i].dcbydy + dy*f[i].d2cbydy )
+                  + dz*( f[i].dcbydz + dz*f[i].d2cbydz );
+    w7 = f[i].cbz + dx*( f[i].dcbzdx + dx*f[i].d2cbzdx )
+                  + dy*( f[i].dcbzdy + dy*f[i].d2cbzdy )
+                  + dz*( f[i].dcbzdz + dz*f[i].d2cbzdz );
+#endif
+#endif
 
     // Boris rotation - curl scalars (0.5 in v0 for half rotate) and
     // kinetic energy computation. Note: gamma-1 = |u|^2 / (gamma+1)
@@ -313,10 +337,13 @@ accumulate_hydro_p_kokkos(
   k_hydro_sv_t k_hydro_sv = Kokkos::Experimental::create_scatter_view(k_hydro);
 
 #ifdef VARIABLE_CHARGE
-  float c, qsp, msp, dt_2mc, dt_4mc, rV;
+  float c, qsp, msp, dt_2mc, dt_4mc, rV, r12V;
 #else
-  float c, qsp, msp, qdt_2mc, qdt_4mc, rV;
+  float c, qsp, msp, qdt_2mc, qdt_4mc, rV, r12V;
 #endif
+
+  constexpr float one=1.0, two=2.0, three=3.0;
+
   //int np, stride_10, stride_21, stride_43;
 
   //float dx, dy, dz, ux, uy, uz, w, vx, vy, vz, ke_mc;
@@ -352,14 +379,17 @@ accumulate_hydro_p_kokkos(
   qdt_4mc  = qdt_2mc / 2;
 #endif
   rV        = 1.0/(sp->g->dx*sp->g->dy*sp->g->dz);
+  r12V      = rV/12.;
 
   const int np        = sp->np;
-  const int stride_10 = VOXEL(1,0,0, sp->g->nx,sp->g->ny,sp->g->nz) -
-                        VOXEL(0,0,0, sp->g->nx,sp->g->ny,sp->g->nz);
-  const int stride_21 = VOXEL(0,1,0, sp->g->nx,sp->g->ny,sp->g->nz) -
-                        VOXEL(1,0,0, sp->g->nx,sp->g->ny,sp->g->nz);
-  const int stride_43 = VOXEL(0,0,1, sp->g->nx,sp->g->ny,sp->g->nz) -
-                        VOXEL(1,1,0, sp->g->nx,sp->g->ny,sp->g->nz);
+  //const int stride_10 = VOXEL(1,0,0, sp->g->nx,sp->g->ny,sp->g->nz) -
+  //                      VOXEL(0,0,0, sp->g->nx,sp->g->ny,sp->g->nz);
+  //const int stride_21 = VOXEL(0,1,0, sp->g->nx,sp->g->ny,sp->g->nz) -
+  //                      VOXEL(1,0,0, sp->g->nx,sp->g->ny,sp->g->nz);
+  //const int stride_43 = VOXEL(0,0,1, sp->g->nx,sp->g->ny,sp->g->nz) -
+  //                      VOXEL(1,1,0, sp->g->nx,sp->g->ny,sp->g->nz);
+  const int sy = sp->g->sy;
+  const int sz = sp->g->sz;
 
   //for( n=0; n<np; n++ ) {
   Kokkos::parallel_for("advance_p", Kokkos::RangePolicy < Kokkos::DefaultExecutionSpace > (0, np),
@@ -381,39 +411,82 @@ accumulate_hydro_p_kokkos(
 #endif
     int ii = k_particles_i(p_index);
 
-    const float cbx = k_interp(ii, interpolator_var::cbx);
-    const float cby = k_interp(ii, interpolator_var::cby);
-    const float cbz = k_interp(ii, interpolator_var::cbz);
+    #define f_ex       k_interp(ii, interpolator_var::ex)
+    #define f_dexdx    k_interp(ii, interpolator_var::dexdx)
+    #define f_dexdy    k_interp(ii, interpolator_var::dexdy)
+    #define f_dexdz    k_interp(ii, interpolator_var::dexdz)
+    #define f_d2exdx   k_interp(ii, interpolator_var::d2exdx)
+    #define f_d2exdy   k_interp(ii, interpolator_var::d2exdy)
+    #define f_d2exdz   k_interp(ii, interpolator_var::d2exdz)
+    #define f_ey       k_interp(ii, interpolator_var::ey)
+    #define f_deydx    k_interp(ii, interpolator_var::deydx)
+    #define f_deydy    k_interp(ii, interpolator_var::deydy)
+    #define f_deydz    k_interp(ii, interpolator_var::deydz)
+    #define f_d2eydx   k_interp(ii, interpolator_var::d2eydx)
+    #define f_d2eydy   k_interp(ii, interpolator_var::d2eydy)
+    #define f_d2eydz   k_interp(ii, interpolator_var::d2eydz)
+    #define f_ez       k_interp(ii, interpolator_var::ez)
+    #define f_dezdx    k_interp(ii, interpolator_var::dezdx)
+    #define f_dezdy    k_interp(ii, interpolator_var::dezdy)
+    #define f_dezdz    k_interp(ii, interpolator_var::dezdz)
+    #define f_d2ezdx   k_interp(ii, interpolator_var::d2ezdx)
+    #define f_d2ezdy   k_interp(ii, interpolator_var::d2ezdy)
+    #define f_d2ezdz   k_interp(ii, interpolator_var::d2ezdz)
+    #define f_cbx      k_interp(ii, interpolator_var::cbx)
+    #define f_dcbxdx   k_interp(ii, interpolator_var::dcbxdx)
+    #define f_dcbxdy   k_interp(ii, interpolator_var::dcbxdy)
+    #define f_dcbxdz   k_interp(ii, interpolator_var::dcbxdz)
+    #define f_d2cbxdx  k_interp(ii, interpolator_var::d2cbxdx)
+    #define f_d2cbxdy  k_interp(ii, interpolator_var::d2cbxdy)
+    #define f_d2cbxdz  k_interp(ii, interpolator_var::d2cbxdz)
+    #define f_cby      k_interp(ii, interpolator_var::cby)
+    #define f_dcbydx   k_interp(ii, interpolator_var::dcbydx)
+    #define f_dcbydy   k_interp(ii, interpolator_var::dcbydy)
+    #define f_dcbydz   k_interp(ii, interpolator_var::dcbydz)
+    #define f_d2cbydx  k_interp(ii, interpolator_var::d2cbydx)
+    #define f_d2cbydy  k_interp(ii, interpolator_var::d2cbydy)
+    #define f_d2cbydz  k_interp(ii, interpolator_var::d2cbydz)
+    #define f_cbz      k_interp(ii, interpolator_var::cbz)
+    #define f_dcbzdx   k_interp(ii, interpolator_var::dcbzdx)
+    #define f_dcbzdy   k_interp(ii, interpolator_var::dcbzdy)
+    #define f_dcbzdz   k_interp(ii, interpolator_var::dcbzdz)
+    #define f_d2cbzdx  k_interp(ii, interpolator_var::d2cbzdx)
+    #define f_d2cbzdy  k_interp(ii, interpolator_var::d2cbzdy)
+    #define f_d2cbzdz  k_interp(ii, interpolator_var::d2cbzdz)
 
-    const float ex = k_interp(ii, interpolator_var::ex);
-    const float ey = k_interp(ii, interpolator_var::ey);
-    const float ez = k_interp(ii, interpolator_var::ez);
-
-    const float dexdy = k_interp(ii, interpolator_var::dexdy);
-    const float deydz = k_interp(ii, interpolator_var::deydz);
-    const float dezdx = k_interp(ii, interpolator_var::dezdx);
-
-    const float dexdz = k_interp(ii, interpolator_var::dexdz);
-    const float deydx = k_interp(ii, interpolator_var::deydx);
-    const float dezdy = k_interp(ii, interpolator_var::dezdy);
-
-    const float d2exdydz = k_interp(ii, interpolator_var::d2exdydz);
-    const float d2eydzdx = k_interp(ii, interpolator_var::d2eydzdx);
-    const float d2ezdxdy = k_interp(ii, interpolator_var::d2ezdxdy);
-
-    const float dcbxdx = k_interp(ii, interpolator_var::dcbxdx);
-    const float dcbydy = k_interp(ii, interpolator_var::dcbydy);
-    const float dcbzdz = k_interp(ii, interpolator_var::dcbzdz);
-
+#ifdef SHAPE_NGP
     // Half advance E
-    ux += qdt_2mc*((ex)); //+dy*dexdy) + dz*(dexdz+dy*d2exdydz));
-    uy += qdt_2mc*((ey)); //+dz*deydz) + dx*(deydx+dz*d2eydzdx));
-    uz += qdt_2mc*((ez)); //+dx*dezdx) + dy*(dezdy+dx*d2ezdxdy));
-
+    ux += qdt_2mc * f_ex;
+    uy += qdt_2mc * f_ey;
+    uz += qdt_2mc * f_ez;
     // Boris rotation - Interpolate B field
-    float w5 = cbx; // + dx*dcbxdx;
-    float w6 = cby; // + dy*dcbydy;
-    float w7 = cbz; // + dz*dcbzdz;
+    float w5 = f_cbx;
+    float w6 = f_cby;
+    float w7 = f_cbz;
+#else
+#ifdef SHAPE_QS
+    // Half advance E
+    ux += qdt_2mc*( f_ex + dx*( f_dexdx + dx*f_d2exdx )
+                         + dy*( f_dexdy + dy*f_d2exdy )
+                         + dz*( f_dexdz + dz*f_d2exdz ) );
+    uy += qdt_2mc*( f_ey + dx*( f_deydx + dx*f_d2eydx )
+                         + dy*( f_deydy + dy*f_d2eydy )
+                         + dz*( f_deydz + dz*f_d2eydz ) );
+    uz += qdt_2mc*( f_ez + dx*( f_dezdx + dx*f_d2ezdx )
+                         + dy*( f_dezdy + dy*f_d2ezdy )
+                         + dz*( f_dezdz + dz*f_d2ezdz ) );
+    // Boris rotation - Interpolate B field
+    float w5 = f_cbx + dx*( f_dcbxdx + dx*f_d2cbxdx )
+                     + dy*( f_dcbxdy + dy*f_d2cbxdy )
+                     + dz*( f_dcbxdz + dz*f_d2cbxdz );
+    float w6 = f_cby + dx*( f_dcbydx + dx*f_d2cbydx )
+                     + dy*( f_dcbydy + dy*f_d2cbydy )
+                     + dz*( f_dcbydz + dz*f_d2cbydz );
+    float w7 = f_cbz + dx*( f_dcbzdx + dx*f_d2cbzdx )
+                     + dy*( f_dcbzdy + dy*f_d2cbzdy )
+                     + dz*( f_dcbzdz + dz*f_d2cbzdz );
+#endif
+#endif
 
     // Boris rotation - curl scalars (0.5 in v0 for half rotate) and
     // kinetic energy computation. Note: gamma-1 = |u|^2 / (gamma+1)
@@ -469,8 +542,22 @@ accumulate_hydro_p_kokkos(
     //w2 *= dz;       // w2 = (1/8)(w/V)(1-x)(1+y)(1-z) = (w/V) trilin_6 *Done
     //w3 *= dz;       // w3 = (1/8)(w/V)(1+x)(1+y)(1-z) = (w/V) trilin_7 *Done
 
-    // Hybrid-VPIC NGP shape
+    // Stencil weights omit species' electric charge.
+    // Charge is accounted for in ACCUM_HYDRO below, in order to distinguish
+    // electric-charge outputs (j, rho) from mass-charge outputs (p, Tij)
+#ifdef SHAPE_NGP
     w0 = w*rV;
+#else
+#ifdef SHAPE_QS
+    w0 =  (w*r12V) * two*( three - dx*dx - dy*dy - dz*dz );
+    float wx =  (w*r12V) * ( dx + one )*( dx + one );
+    float wy =  (w*r12V) * ( dy + one )*( dy + one );
+    float wz =  (w*r12V) * ( dz + one )*( dz + one );
+    float wmx = (w*r12V) * ( dx - one )*( dx - one );
+    float wmy = (w*r12V) * ( dy - one )*( dy - one );
+    float wmz = (w*r12V) * ( dz - one )*( dz - one );
+#endif
+#endif
 
     // TODO: This could easily be a loop?
 
@@ -536,9 +623,9 @@ accumulate_hydro_p_kokkos(
 
     // TODO: this serial adding to try and save adds is a bit sad
     // TODO: This is somehow going out of bounds right now
-    const int i0 = ii;
-    ACCUM_HYDRO(w0, i0); // Cell i,j,k
-
+//    const int i0 = ii;
+//    ACCUM_HYDRO(w0, i0); // Cell i,j,k
+//
 //    const int i1 = i0 + stride_10;
 //    ACCUM_HYDRO(w1, i1); // Cell i+1,j,k
 //
@@ -559,6 +646,20 @@ accumulate_hydro_p_kokkos(
 //
 //    const int i7 = i6 + stride_10;
 //    ACCUM_HYDRO(w7, i7); // Cell i+1,j+1,k+1
+
+#ifdef SHAPE_NGP
+    ACCUM_HYDRO(w0, ii); // Cell i,j,k
+#else
+#ifdef SHAPE_QS
+    ACCUM_HYDRO(w0,  ii     ); // Cell i,j,k
+    ACCUM_HYDRO(wx,  ii +  1); // Cell i+1,j,k
+    ACCUM_HYDRO(wy,  ii + sy); // Cell i,j+1,k
+    ACCUM_HYDRO(wz,  ii + sz); // Cell i,j,k+1
+    ACCUM_HYDRO(wmx, ii -  1); // Cell i-1,j,k
+    ACCUM_HYDRO(wmy, ii - sy); // Cell i,j-1,k
+    ACCUM_HYDRO(wmz, ii - sz); // Cell i,j,k-1
+#endif
+#endif
 
 #   undef ACCUM_HYDRO
   });
@@ -582,6 +683,49 @@ accumulate_hydro_p_kokkos(
   
   Kokkos::Experimental::contribute(k_hydro, k_hydro_sv);
   Kokkos::fence(); // TODO: Check if I need this to block the contribute
+
+  #undef f_ex
+  #undef f_dexdx
+  #undef f_dexdy
+  #undef f_dexdz
+  #undef f_d2exdx
+  #undef f_d2exdy
+  #undef f_d2exdz
+  #undef f_ey
+  #undef f_deydx
+  #undef f_deydy
+  #undef f_deydz
+  #undef f_d2eydx
+  #undef f_d2eydy
+  #undef f_d2eydz
+  #undef f_ez
+  #undef f_dezdx
+  #undef f_dezdy
+  #undef f_dezdz
+  #undef f_d2ezdx
+  #undef f_d2ezdy
+  #undef f_d2ezdz
+  #undef f_cbx
+  #undef f_dcbxdx
+  #undef f_dcbxdy
+  #undef f_dcbxdz
+  #undef f_d2cbxdx
+  #undef f_d2cbxdy
+  #undef f_d2cbxdz
+  #undef f_cby
+  #undef f_dcbydx
+  #undef f_dcbydy
+  #undef f_dcbydz
+  #undef f_d2cbydx
+  #undef f_d2cbydy
+  #undef f_d2cbydz
+  #undef f_cbz
+  #undef f_dcbzdx
+  #undef f_dcbzdy
+  #undef f_dcbzdz
+  #undef f_d2cbzdx
+  #undef f_d2cbzdy
+  #undef f_d2cbzdz
 
   // Perform debug printing
 }

--- a/src/species_advance/standard/hydro_p.cc
+++ b/src/species_advance/standard/hydro_p.cc
@@ -82,8 +82,7 @@ accumulate_hydro_p( hydro_array_t              * RESTRICT ha,
     w5 = f[i].cbx;
     w6 = f[i].cby;
     w7 = f[i].cbz;
-#else
-#ifdef SHAPE_QS
+#elif defined( SHAPE_QS )
     // Half advance E
     ux += qdt_2mc*( f[i].ex + dx*( f[i].dexdx + dx*f[i].d2exdx )
                             + dy*( f[i].dexdy + dy*f[i].d2exdy )
@@ -104,7 +103,6 @@ accumulate_hydro_p( hydro_array_t              * RESTRICT ha,
     w7 = f[i].cbz + dx*( f[i].dcbzdx + dx*f[i].d2cbzdx )
                   + dy*( f[i].dcbzdy + dy*f[i].d2cbzdy )
                   + dz*( f[i].dcbzdz + dz*f[i].d2cbzdz );
-#endif
 #endif
 
     // Boris rotation - curl scalars (0.5 in v0 for half rotate) and
@@ -342,7 +340,7 @@ accumulate_hydro_p_kokkos(
   float c, qsp, msp, qdt_2mc, qdt_4mc, rV, r12V;
 #endif
 
-  constexpr float one=1.0, two=2.0, three=3.0;
+  constexpr float one=1.0f, two=2.0f, three=3.0f;
 
   //int np, stride_10, stride_21, stride_43;
 
@@ -378,8 +376,8 @@ accumulate_hydro_p_kokkos(
   qdt_2mc  = (qsp*sp->g->dt)/(2*msp*c);
   qdt_4mc  = qdt_2mc / 2;
 #endif
-  rV        = 1.0/(sp->g->dx*sp->g->dy*sp->g->dz);
-  r12V      = rV/12.;
+  rV        = 1.f/(sp->g->dx*sp->g->dy*sp->g->dz);
+  r12V      = rV/12.f;
 
   const int np        = sp->np;
   //const int stride_10 = VOXEL(1,0,0, sp->g->nx,sp->g->ny,sp->g->nz) -
@@ -463,8 +461,7 @@ accumulate_hydro_p_kokkos(
     float w5 = f_cbx;
     float w6 = f_cby;
     float w7 = f_cbz;
-#else
-#ifdef SHAPE_QS
+#elif defined( SHAPE_QS )
     // Half advance E
     ux += qdt_2mc*( f_ex + dx*( f_dexdx + dx*f_d2exdx )
                          + dy*( f_dexdy + dy*f_d2exdy )
@@ -485,7 +482,6 @@ accumulate_hydro_p_kokkos(
     float w7 = f_cbz + dx*( f_dcbzdx + dx*f_d2cbzdx )
                      + dy*( f_dcbzdy + dy*f_d2cbzdy )
                      + dz*( f_dcbzdz + dz*f_d2cbzdz );
-#endif
 #endif
 
     // Boris rotation - curl scalars (0.5 in v0 for half rotate) and
@@ -547,8 +543,7 @@ accumulate_hydro_p_kokkos(
     // electric-charge outputs (j, rho) from mass-charge outputs (p, Tij)
 #ifdef SHAPE_NGP
     w0 = w*rV;
-#else
-#ifdef SHAPE_QS
+#elif defined( SHAPE_QS )
     w0 =  (w*r12V) * two*( three - dx*dx - dy*dy - dz*dz );
     float wx =  (w*r12V) * ( dx + one )*( dx + one );
     float wy =  (w*r12V) * ( dy + one )*( dy + one );
@@ -556,7 +551,6 @@ accumulate_hydro_p_kokkos(
     float wmx = (w*r12V) * ( dx - one )*( dx - one );
     float wmy = (w*r12V) * ( dy - one )*( dy - one );
     float wmz = (w*r12V) * ( dz - one )*( dz - one );
-#endif
 #endif
 
     // TODO: This could easily be a loop?
@@ -649,8 +643,7 @@ accumulate_hydro_p_kokkos(
 
 #ifdef SHAPE_NGP
     ACCUM_HYDRO(w0, ii); // Cell i,j,k
-#else
-#ifdef SHAPE_QS
+#elif defined( SHAPE_QS )
     ACCUM_HYDRO(w0,  ii     ); // Cell i,j,k
     ACCUM_HYDRO(wx,  ii +  1); // Cell i+1,j,k
     ACCUM_HYDRO(wy,  ii + sy); // Cell i,j+1,k
@@ -658,7 +651,6 @@ accumulate_hydro_p_kokkos(
     ACCUM_HYDRO(wmx, ii -  1); // Cell i-1,j,k
     ACCUM_HYDRO(wmy, ii - sy); // Cell i,j-1,k
     ACCUM_HYDRO(wmz, ii - sz); // Cell i,j,k-1
-#endif
 #endif
 
 #   undef ACCUM_HYDRO

--- a/src/species_advance/standard/rho_p.cc
+++ b/src/species_advance/standard/rho_p.cc
@@ -32,13 +32,21 @@ accumulate_rho_p( /**/  field_array_t * RESTRICT fa,
     /**/  field_t    * RESTRICT ALIGNED(128) f = fa->f;
     const particle_t * RESTRICT ALIGNED(128) p = sp->p;
 
-    const float q_8V = sp->q*sp->g->r8V, one=1.0;
+    const float q_8V  = sp->q*sp->g->r8V;
+    const float q_V   = sp->q*(sp->g->rdx*sp->g->rdy*sp->g->rdz);
+    const float q_12V = q_V * 1./12.;
     const int np = sp->np;
     const int sy = sp->g->sy;
     const int sz = sp->g->sz;
 
+    constexpr float three          = 3.;
+    constexpr float two            = 2.;
+    constexpr float one            = 1.;
+
 # if 1
-    float ux, uy, uz, w3, w4, w5, w6, w7, dz;
+    float ux, uy, uz; //, w3, w4, w5, w6, w7, dz;
+    float dx, dy, dz;
+    float q, w0, wx, wy, wz, wmx, wmy, wmz;
 # else
     using namespace v4;
     v4float q, wl, wh, rl, rh;
@@ -61,15 +69,13 @@ accumulate_rho_p( /**/  field_array_t * RESTRICT fa,
         ux = p[n].ux;
         uy = p[n].uy;
         uz = p[n].uz;
+        v  = p[n].i;
 
         // Disable relativistic gamma for Hybrid PIC
         //w3  = one/sqrtf(one + (ux*ux+ (uy*uy + uz*uz)));
         //ux *= w3;
         //uy *= w3;
         //uz *= w3;
-
-	v  = p[n].i;
-        w7 = p[n].w*q_8V*8.0;
 
         // Compute the trilinear weights
         // Though the PPE should have hardware fma/fmaf support, it was
@@ -89,10 +95,66 @@ accumulate_rho_p( /**/  field_array_t * RESTRICT fa,
 
         // Reduce the particle charge to rhof
 
-        f[v      ].jfx += w7*ux;
-	f[v      ].jfy += w7*uy;
-        f[v      ].jfz += w7*uz;
-	f[v      ].rhof+= w7;
+#ifdef SHAPE_NGP
+        w0 = p[n].w * q_V;
+
+        f[v      ].jfx += w0*ux;
+        f[v      ].jfy += w0*uy;
+        f[v      ].jfz += w0*uz;
+        f[v      ].rhof+= w0;
+#else
+#ifdef SHAPE_QS
+
+        dx = p[n].dx;
+        dy = p[n].dy;
+        dz = p[n].dz;
+
+        q = p[n].w * q_12V;
+        w0 =  q*two*( three - dx*dx - dy*dy - dz*dz );
+        wx =  q*( dx + one )*( dx + one );
+        wy =  q*( dy + one )*( dy + one );
+        wz =  q*( dz + one )*( dz + one );
+        wmx = q*( dx - one )*( dx - one );
+        wmy = q*( dy - one )*( dy - one );
+        wmz = q*( dz - one )*( dz - one );
+
+        f[v   ].jfx  += w0*ux;
+        f[v   ].jfy  += w0*uy;
+        f[v   ].jfz  += w0*uz;
+        f[v   ].rhof += w0;
+
+        f[v+1 ].jfx  += wx*ux;
+        f[v+1 ].jfy  += wx*uy;
+        f[v+1 ].jfz  += wx*uz;
+        f[v+1 ].rhof += wx;
+
+        f[v+sy].jfx  += wy*ux;
+        f[v+sy].jfy  += wy*uy;
+        f[v+sy].jfz  += wy*uz;
+        f[v+sy].rhof += wy;
+
+        f[v+sz].jfx  += wz*ux;
+        f[v+sz].jfy  += wz*uy;
+        f[v+sz].jfz  += wz*uz;
+        f[v+sz].rhof += wz;
+
+        f[v-1 ].jfx  += wmx*ux;
+        f[v-1 ].jfy  += wmx*uy;
+        f[v-1 ].jfz  += wmx*uz;
+        f[v-1 ].rhof += wmx;
+
+        f[v-sy].jfx  += wmy*ux;
+        f[v-sy].jfy  += wmy*uy;
+        f[v-sy].jfz  += wmy*uz;
+        f[v-sy].rhof += wmy;
+
+        f[v-sz].jfx  += wmz*ux;
+        f[v-sz].jfy  += wmz*uy;
+        f[v-sz].jfz  += wmz*uz;
+        f[v-sz].rhof += wmz;
+
+#endif // defined(SHAPE_QS)
+#endif // defined(SHAPE_NGP)
 
 	//  ; f[v      +1].rhof += w1;
         //f[v   +sy].rhof += w2; f[v   +sy+1].rhof += w3;
@@ -480,9 +542,15 @@ k_accumulate_rho_p( /**/  field_array_t * RESTRICT fa,
     k_particles_i_t kparticles_i = sp->k_p_i_d;
 
     const float q_8V = (sp->q)*(sp->g->r8V);
+    const float q_V   = sp->q*(sp->g->rdx*sp->g->rdy*sp->g->rdz);
+    const float q_12V = q_V * 1./12.;
     const int np = sp->np;
     const int sy = sp->g->sy;
     const int sz = sp->g->sz;
+
+    constexpr float three          = 3.;
+    constexpr float two            = 2.;
+    constexpr float one            = 1.;
 /*
     float sums[sp->g->nv];
     Kokkos::parallel_reduce("accumulate_rho_p", Kokkos::RangePolicy<>(0, np), accum_rho_p_reduce(kfield, kparticles, kparticles_i, sy, sz, q_8V, np, sp->g->nv), sums);
@@ -528,10 +596,13 @@ k_accumulate_rho_p( /**/  field_array_t * RESTRICT fa,
 
         // Hybrid
         int ii = kparticles_i(n);
+        float dx  =            kparticles(n, particle_var::dx);
+        float dy  =            kparticles(n, particle_var::dy);
+        float dz  =            kparticles(n, particle_var::dz);
         float ux  =            kparticles(n, particle_var::ux);
         float uy  =            kparticles(n, particle_var::uy);
         float uz  =            kparticles(n, particle_var::uz);
-        float q_V = q_8V*8.0 * kparticles(n, particle_var::w);
+        float p_w =            kparticles(n, particle_var::w);
 
         auto scatter_view_access = scatter_view.access();
 
@@ -553,11 +624,60 @@ k_accumulate_rho_p( /**/  field_array_t * RESTRICT fa,
 //        Kokkos::atomic_add(&kfield(v+sz+sy,   field_var::rhof), w6);
 //        Kokkos::atomic_add(&kfield(v+sz+sy+1, field_var::rhof), w7);
 
+#ifdef SHAPE_NGP
         // Hybrid, nearest-grid-point shape
-        scatter_view_access(ii, field_var::jfx)  += q_V * ux;
-        scatter_view_access(ii, field_var::jfy)  += q_V * uy;
-        scatter_view_access(ii, field_var::jfz)  += q_V * uz;
-        scatter_view_access(ii, field_var::rhof) += q_V;
+        float w0 = q_V * p_w;
+
+        scatter_view_access(ii, field_var::jfx)  += w0 * ux;
+        scatter_view_access(ii, field_var::jfy)  += w0 * uy;
+        scatter_view_access(ii, field_var::jfz)  += w0 * uz;
+        scatter_view_access(ii, field_var::rhof) += w0;
+#else
+#ifdef SHAPE_QS
+        float w0 =  (q_12V*p_w) * two*( three - dx*dx - dy*dy - dz*dz );
+        float wx =  (q_12V*p_w) * ( dx + one )*( dx + one );
+        float wy =  (q_12V*p_w) * ( dy + one )*( dy + one );
+        float wz =  (q_12V*p_w) * ( dz + one )*( dz + one );
+        float wmx = (q_12V*p_w) * ( dx - one )*( dx - one );
+        float wmy = (q_12V*p_w) * ( dy - one )*( dy - one );
+        float wmz = (q_12V*p_w) * ( dz - one )*( dz - one );
+
+        scatter_view_access(ii,    field_var::jfx)  += w0 * ux;
+        scatter_view_access(ii,    field_var::jfy)  += w0 * uy;
+        scatter_view_access(ii,    field_var::jfz)  += w0 * uz;
+        scatter_view_access(ii,    field_var::rhof) += w0;
+
+        scatter_view_access(ii+1,  field_var::jfx)  += wx * ux;
+        scatter_view_access(ii+1,  field_var::jfy)  += wx * uy;
+        scatter_view_access(ii+1,  field_var::jfz)  += wx * uz;
+        scatter_view_access(ii+1,  field_var::rhof) += wx;
+
+        scatter_view_access(ii+sy, field_var::jfx)  += wy * ux;
+        scatter_view_access(ii+sy, field_var::jfy)  += wy * uy;
+        scatter_view_access(ii+sy, field_var::jfz)  += wy * uz;
+        scatter_view_access(ii+sy, field_var::rhof) += wy;
+
+        scatter_view_access(ii+sz, field_var::jfx)  += wz * ux;
+        scatter_view_access(ii+sz, field_var::jfy)  += wz * uy;
+        scatter_view_access(ii+sz, field_var::jfz)  += wz * uz;
+        scatter_view_access(ii+sz, field_var::rhof) += wz;
+
+        scatter_view_access(ii-1,  field_var::jfx)  += wmx * ux;
+        scatter_view_access(ii-1,  field_var::jfy)  += wmx * uy;
+        scatter_view_access(ii-1,  field_var::jfz)  += wmx * uz;
+        scatter_view_access(ii-1,  field_var::rhof) += wmx;
+
+        scatter_view_access(ii-sy, field_var::jfx)  += wmy * ux;
+        scatter_view_access(ii-sy, field_var::jfy)  += wmy * uy;
+        scatter_view_access(ii-sy, field_var::jfz)  += wmy * uz;
+        scatter_view_access(ii-sy, field_var::rhof) += wmy;
+
+        scatter_view_access(ii-sz, field_var::jfx)  += wmz * ux;
+        scatter_view_access(ii-sz, field_var::jfy)  += wmz * uy;
+        scatter_view_access(ii-sz, field_var::jfz)  += wmz * uz;
+        scatter_view_access(ii-sz, field_var::rhof) += wmz;
+#endif // defined(SHAPE_QS)
+#endif // defined(SHAPE_NGP)
 
     });
     Kokkos::Experimental::contribute(kfield, scatter_view);

--- a/src/species_advance/standard/rho_p.cc
+++ b/src/species_advance/standard/rho_p.cc
@@ -102,8 +102,7 @@ accumulate_rho_p( /**/  field_array_t * RESTRICT fa,
         f[v      ].jfy += w0*uy;
         f[v      ].jfz += w0*uz;
         f[v      ].rhof+= w0;
-#else
-#ifdef SHAPE_QS
+#elif defined( SHAPE_QS )
 
         dx = p[n].dx;
         dy = p[n].dy;
@@ -153,7 +152,6 @@ accumulate_rho_p( /**/  field_array_t * RESTRICT fa,
         f[v-sz].jfz  += wmz*uz;
         f[v-sz].rhof += wmz;
 
-#endif // defined(SHAPE_QS)
 #endif // defined(SHAPE_NGP)
 
 	//  ; f[v      +1].rhof += w1;
@@ -632,8 +630,7 @@ k_accumulate_rho_p( /**/  field_array_t * RESTRICT fa,
         scatter_view_access(ii, field_var::jfy)  += w0 * uy;
         scatter_view_access(ii, field_var::jfz)  += w0 * uz;
         scatter_view_access(ii, field_var::rhof) += w0;
-#else
-#ifdef SHAPE_QS
+#elif defined( SHAPE_QS )
         float w0 =  (q_12V*p_w) * two*( three - dx*dx - dy*dy - dz*dz );
         float wx =  (q_12V*p_w) * ( dx + one )*( dx + one );
         float wy =  (q_12V*p_w) * ( dy + one )*( dy + one );
@@ -676,7 +673,6 @@ k_accumulate_rho_p( /**/  field_array_t * RESTRICT fa,
         scatter_view_access(ii-sz, field_var::jfy)  += wmz * uy;
         scatter_view_access(ii-sz, field_var::jfz)  += wmz * uz;
         scatter_view_access(ii-sz, field_var::rhof) += wmz;
-#endif // defined(SHAPE_QS)
 #endif // defined(SHAPE_NGP)
 
     });

--- a/src/species_advance/standard/uncenter_p.cc
+++ b/src/species_advance/standard/uncenter_p.cc
@@ -32,28 +32,48 @@ void uncenter_p_kokkos(
   #define pii     k_particles_i(p_index)
 
   // Interpolator Defines (f->x)
-  #define f_cbx k_interp(ii, interpolator_var::cbx)
-  #define f_cby k_interp(ii, interpolator_var::cby)
-  #define f_cbz k_interp(ii, interpolator_var::cbz)
-  #define f_ex  k_interp(ii, interpolator_var::ex)
-  #define f_ey  k_interp(ii, interpolator_var::ey)
-  #define f_ez  k_interp(ii, interpolator_var::ez)
-
+  #define f_ex       k_interp(ii, interpolator_var::ex)
+  #define f_dexdx    k_interp(ii, interpolator_var::dexdx)
   #define f_dexdy    k_interp(ii, interpolator_var::dexdy)
   #define f_dexdz    k_interp(ii, interpolator_var::dexdz)
-
-  #define f_d2exdydz k_interp(ii, interpolator_var::d2exdydz)
+  #define f_d2exdx   k_interp(ii, interpolator_var::d2exdx)
+  #define f_d2exdy   k_interp(ii, interpolator_var::d2exdy)
+  #define f_d2exdz   k_interp(ii, interpolator_var::d2exdz)
+  #define f_ey       k_interp(ii, interpolator_var::ey)
   #define f_deydx    k_interp(ii, interpolator_var::deydx)
+  #define f_deydy    k_interp(ii, interpolator_var::deydy)
   #define f_deydz    k_interp(ii, interpolator_var::deydz)
-
-  #define f_d2eydzdx k_interp(ii, interpolator_var::d2eydzdx)
+  #define f_d2eydx   k_interp(ii, interpolator_var::d2eydx)
+  #define f_d2eydy   k_interp(ii, interpolator_var::d2eydy)
+  #define f_d2eydz   k_interp(ii, interpolator_var::d2eydz)
+  #define f_ez       k_interp(ii, interpolator_var::ez)
   #define f_dezdx    k_interp(ii, interpolator_var::dezdx)
   #define f_dezdy    k_interp(ii, interpolator_var::dezdy)
-
-  #define f_d2ezdxdy k_interp(ii, interpolator_var::d2ezdxdy)
+  #define f_dezdz    k_interp(ii, interpolator_var::dezdz)
+  #define f_d2ezdx   k_interp(ii, interpolator_var::d2ezdx)
+  #define f_d2ezdy   k_interp(ii, interpolator_var::d2ezdy)
+  #define f_d2ezdz   k_interp(ii, interpolator_var::d2ezdz)
+  #define f_cbx      k_interp(ii, interpolator_var::cbx)
   #define f_dcbxdx   k_interp(ii, interpolator_var::dcbxdx)
+  #define f_dcbxdy   k_interp(ii, interpolator_var::dcbxdy)
+  #define f_dcbxdz   k_interp(ii, interpolator_var::dcbxdz)
+  #define f_d2cbxdx  k_interp(ii, interpolator_var::d2cbxdx)
+  #define f_d2cbxdy  k_interp(ii, interpolator_var::d2cbxdy)
+  #define f_d2cbxdz  k_interp(ii, interpolator_var::d2cbxdz)
+  #define f_cby      k_interp(ii, interpolator_var::cby)
+  #define f_dcbydx   k_interp(ii, interpolator_var::dcbydx)
   #define f_dcbydy   k_interp(ii, interpolator_var::dcbydy)
+  #define f_dcbydz   k_interp(ii, interpolator_var::dcbydz)
+  #define f_d2cbydx  k_interp(ii, interpolator_var::d2cbydx)
+  #define f_d2cbydy  k_interp(ii, interpolator_var::d2cbydy)
+  #define f_d2cbydz  k_interp(ii, interpolator_var::d2cbydz)
+  #define f_cbz      k_interp(ii, interpolator_var::cbz)
+  #define f_dcbzdx   k_interp(ii, interpolator_var::dcbzdx)
+  #define f_dcbzdy   k_interp(ii, interpolator_var::dcbzdy)
   #define f_dcbzdz   k_interp(ii, interpolator_var::dcbzdz)
+  #define f_d2cbzdx  k_interp(ii, interpolator_var::d2cbzdx)
+  #define f_d2cbzdy  k_interp(ii, interpolator_var::d2cbzdy)
+  #define f_d2cbzdz  k_interp(ii, interpolator_var::d2cbzdz)
 
 
   // this goes to np using p_index
@@ -69,12 +89,35 @@ void uncenter_p_kokkos(
     float qdt_4mc = 0.5*qdt_2mc;   // For backwards half rotation
 #endif
     
+#ifdef SHAPE_NGP
     hax  = qdt_2mc*(      ( f_ex    ) );
     hay  = qdt_2mc*(      ( f_ey    ) );
     haz  = qdt_2mc*(      ( f_ez    ) );
     l_cbx  = f_cbx;// + p_dx*f_dcbxdx;            // Interpolate B
     l_cby  = f_cby;// + p_dy*f_dcbydy;
     l_cbz  = f_cbz;// + p_dz*f_dcbzdz;
+#else
+#ifdef SHAPE_QS
+    hax  = qdt_2mc*( f_ex + p_dx*( f_dexdx + p_dx*f_d2exdx )      // Interpolate E
+                          + p_dy*( f_dexdy + p_dy*f_d2exdy )
+                          + p_dz*( f_dexdz + p_dz*f_d2exdz ) );
+    hay  = qdt_2mc*( f_ey + p_dx*( f_deydx + p_dx*f_d2eydx )
+                          + p_dy*( f_deydy + p_dy*f_d2eydy )
+                          + p_dz*( f_deydz + p_dz*f_d2eydz ) );
+    haz  = qdt_2mc*( f_ez + p_dx*( f_dezdx + p_dx*f_d2ezdx )
+                          + p_dy*( f_dezdy + p_dy*f_d2ezdy )
+                          + p_dz*( f_dezdz + p_dz*f_d2ezdz ) );
+    l_cbx  = f_cbx + p_dx*( f_dcbxdx + p_dx*f_d2cbxdx )             // Interpolate B
+                   + p_dy*( f_dcbxdy + p_dy*f_d2cbxdy )
+                   + p_dz*( f_dcbxdz + p_dz*f_d2cbxdz );
+    l_cby  = f_cby + p_dx*( f_dcbydx + p_dx*f_d2cbydx )
+                   + p_dy*( f_dcbydy + p_dy*f_d2cbydy )
+                   + p_dz*( f_dcbydz + p_dz*f_d2cbydz );
+    l_cbz  = f_cbz + p_dx*( f_dcbzdx + p_dx*f_d2cbzdx )
+                   + p_dy*( f_dcbzdy + p_dy*f_d2cbzdy )
+                   + p_dz*( f_dcbzdz + p_dz*f_d2cbzdz );
+#endif
+#endif
     v0   = qdt_4mc;///(float)sqrt(one + (p_ux*p_ux + (p_uy*p_uy + p_uz*p_uz)));
     /**/                                     // Boris - scalars
     v1    = l_cbx*l_cbx + (l_cby*l_cby + l_cbz*l_cbz);

--- a/src/species_advance/standard/uncenter_p.cc
+++ b/src/species_advance/standard/uncenter_p.cc
@@ -90,14 +90,13 @@ void uncenter_p_kokkos(
 #endif
     
 #ifdef SHAPE_NGP
-    hax  = qdt_2mc*(      ( f_ex    ) );
-    hay  = qdt_2mc*(      ( f_ey    ) );
-    haz  = qdt_2mc*(      ( f_ez    ) );
-    l_cbx  = f_cbx;// + p_dx*f_dcbxdx;            // Interpolate B
-    l_cby  = f_cby;// + p_dy*f_dcbydy;
-    l_cbz  = f_cbz;// + p_dz*f_dcbzdz;
-#else
-#ifdef SHAPE_QS
+    hax  = qdt_2mc*f_ex; // Interpolate E
+    hay  = qdt_2mc*f_ey;
+    haz  = qdt_2mc*f_ez;
+    l_cbx  = f_cbx;            // Interpolate B
+    l_cby  = f_cby;
+    l_cbz  = f_cbz;
+#elif defined( SHAPE_QS )
     hax  = qdt_2mc*( f_ex + p_dx*( f_dexdx + p_dx*f_d2exdx )      // Interpolate E
                           + p_dy*( f_dexdy + p_dy*f_d2exdy )
                           + p_dz*( f_dexdz + p_dz*f_d2exdz ) );
@@ -117,7 +116,6 @@ void uncenter_p_kokkos(
                    + p_dy*( f_dcbzdy + p_dy*f_d2cbzdy )
                    + p_dz*( f_dcbzdz + p_dz*f_d2cbzdz );
 #endif
-#endif
     v0   = qdt_4mc;///(float)sqrt(one + (p_ux*p_ux + (p_uy*p_uy + p_uz*p_uz)));
     /**/                                     // Boris - scalars
     v1    = l_cbx*l_cbx + (l_cby*l_cby + l_cbz*l_cbz);
@@ -135,7 +133,6 @@ void uncenter_p_kokkos(
     p_uy += hay;
     p_uz += haz;
   });
-
 }
 
 void

--- a/src/vpic/initialize.cc
+++ b/src/vpic/initialize.cc
@@ -31,6 +31,10 @@ vpic_simulation::initialize( int argc,
   grid->eos_den       = 1.;
   grid->kappa         = 0;
 
+  // need isub=0 initialized for advance_b(...) to
+  // migrate QS shape currents from ghosts to live cells
+  grid->isub          = 0;
+
   // Call the user initialize the simulation
 
   TIC user_initialization( argc, argv ); TOC( user_initialization, 1 );

--- a/src/vpic/kokkos_helpers.h
+++ b/src/vpic/kokkos_helpers.h
@@ -32,10 +32,8 @@
 
 #ifdef SHAPE_NGP
   #define INTERPOLATOR_VAR_COUNT 6
-#else
-#ifdef SHAPE_QS
+#elif defined( SHAPE_QS )
   #define INTERPOLATOR_VAR_COUNT 42
-#endif
 #endif
 
 #ifdef KOKKOS_ENABLE_CUDA
@@ -221,8 +219,7 @@ namespace interpolator_var {
     cbx      = 3,
     cby      = 4,
     cbz      = 5,
-#else
-#ifdef SHAPE_QS
+#elif defined( SHAPE_QS )
     ex       = 0,
     dexdx    = 1,
     dexdy    = 2,
@@ -265,7 +262,6 @@ namespace interpolator_var {
     d2cbzdx  = 39,
     d2cbzdy  = 40,
     d2cbzdz  = 41,
-#endif
 #endif
   };
 };

--- a/src/vpic/kokkos_helpers.h
+++ b/src/vpic/kokkos_helpers.h
@@ -21,7 +21,6 @@
 #define PARTICLE_MOVER_VAR_COUNT 3
 #define ACCUMULATOR_VAR_COUNT 4
 #define ACCUMULATOR_ARRAY_LENGTH 4
-#define INTERPOLATOR_VAR_COUNT 18
 #define MATERIAL_COEFFICIENT_VAR_COUNT 13
 #ifdef VARIABLE_CHARGE
   #define HYDRO_VAR_COUNT 16
@@ -30,6 +29,14 @@
 #endif
 #define NUM_J_DIMS 4
 #define FLUID_VAR_COUNT 6+4
+
+#ifdef SHAPE_NGP
+  #define INTERPOLATOR_VAR_COUNT 18
+#else
+#ifdef SHAPE_QS
+  #define INTERPOLATOR_VAR_COUNT 42
+#endif
+#endif
 
 #ifdef KOKKOS_ENABLE_CUDA
   #define KOKKOS_SCATTER_DUPLICATED Kokkos::Experimental::ScatterNonDuplicated
@@ -207,6 +214,7 @@ namespace field_edge_var { \
 
 namespace interpolator_var {
   enum i_r {
+#ifdef SHAPE_NGP
     ex       = 0,
     dexdy    = 1,
     dexdz    = 2,
@@ -225,6 +233,52 @@ namespace interpolator_var {
     dcbydy   = 15,
     cbz      = 16,
     dcbzdz   = 17,
+#else
+#ifdef SHAPE_QS
+    ex       = 0,
+    dexdx    = 1,
+    dexdy    = 2,
+    dexdz    = 3,
+    d2exdx   = 4,
+    d2exdy   = 5,
+    d2exdz   = 6,
+    ey       = 7,
+    deydx    = 8,
+    deydy    = 9,
+    deydz    = 10,
+    d2eydx   = 11,
+    d2eydy   = 12,
+    d2eydz   = 13,
+    ez       = 14,
+    dezdx    = 15,
+    dezdy    = 16,
+    dezdz    = 17,
+    d2ezdx   = 18,
+    d2ezdy   = 19,
+    d2ezdz   = 20,
+    cbx      = 21,
+    dcbxdx   = 22,
+    dcbxdy   = 23,
+    dcbxdz   = 24,
+    d2cbxdx  = 25,
+    d2cbxdy  = 26,
+    d2cbxdz  = 27,
+    cby      = 28,
+    dcbydx   = 29,
+    dcbydy   = 30,
+    dcbydz   = 31,
+    d2cbydx  = 32,
+    d2cbydy  = 33,
+    d2cbydz  = 34,
+    cbz      = 35,
+    dcbzdx   = 36,
+    dcbzdy   = 37,
+    dcbzdz   = 38,
+    d2cbzdx  = 39,
+    d2cbzdy  = 40,
+    d2cbzdz  = 41,
+#endif
+#endif
   };
 };
 

--- a/src/vpic/kokkos_helpers.h
+++ b/src/vpic/kokkos_helpers.h
@@ -31,7 +31,7 @@
 #define FLUID_VAR_COUNT 6+4
 
 #ifdef SHAPE_NGP
-  #define INTERPOLATOR_VAR_COUNT 18
+  #define INTERPOLATOR_VAR_COUNT 6
 #else
 #ifdef SHAPE_QS
   #define INTERPOLATOR_VAR_COUNT 42
@@ -216,23 +216,11 @@ namespace interpolator_var {
   enum i_r {
 #ifdef SHAPE_NGP
     ex       = 0,
-    dexdy    = 1,
-    dexdz    = 2,
-    d2exdydz = 3,
-    ey       = 4,
-    deydz    = 5,
-    deydx    = 6,
-    d2eydzdx = 7,
-    ez       = 8,
-    dezdx    = 9,
-    dezdy    = 10,
-    d2ezdxdy = 11,
-    cbx      = 12,
-    dcbxdx   = 13,
-    cby      = 14,
-    dcbydy   = 15,
-    cbz      = 16,
-    dcbzdz   = 17,
+    ey       = 1,
+    ez       = 2,
+    cbx      = 3,
+    cby      = 4,
+    cbz      = 5,
 #else
 #ifdef SHAPE_QS
     ex       = 0,


### PR DESCRIPTION
In `arch/` files, add the flag `-DVPIC_SHAPE_QS` to enable quadratic-sum (QS) particle shape.  Without this flag, nearest-grid-point (NGP) shape will be used by default, which ensures backwards compatibility.

QS shape is slower than NGP shape; no substantial attempt has been made to optimize performance yet.

QS shape is not implemented with `HYB_USE_STATIC_E` , `HYB_USE_SEPARATE_PE` , which would need corresponding updates + tests of `hyb_advance_bpe(...)` in either (or both?) of `hyb_advance_bpe.cc` or `hyb_advance_pe.cc`